### PR TITLE
allows thinning in non-posterior epochs

### DIFF
--- a/liesel/goose/builder.py
+++ b/liesel/goose/builder.py
@@ -137,21 +137,21 @@ class EngineBuilder:
         warmup_duration: int,
         posterior_duration: int,
         term_duration: int = 50,
-        thinning: int = 1,
+        thinning_posterior: int = 1,
+        thinning_warmup: int = 1,
     ):
         """
         Sets epochs using the `stan_epochs` function.
 
         Note that `term_duration` needs to be long enough that tuning algorithms
         like dual averaging can converge.
-
-        Thinning is only applied in the posterior epoch.
         """
         epochs = stan_epochs(
             warmup_duration,
             posterior_duration,
             term_duration=term_duration,
-            thinning=thinning,
+            thinning_posterior=thinning_posterior,
+            thinning_warmup=thinning_warmup,
         )
         self._epochs = EpochManager(epochs)
 

--- a/liesel/goose/epoch.py
+++ b/liesel/goose/epoch.py
@@ -136,15 +136,16 @@ class EpochManager:
         if config.duration < 1:
             raise RuntimeError("Duration must be greater than or equal to 1")
 
+        if config.thinning < 1:
+            raise RuntimeError("Thinning must be greater than or equal to 1")
+
         if config.thinning != 1:
+            if config.duration < config.thinning:
+                raise RuntimeError("Duration must be greater than or equal to thinning")
+
             if config.type == EpochType.POSTERIOR:
                 if config.duration % config.thinning != 0:
                     raise RuntimeError("Duration must be a multiple of thinning")
-            else:
-                raise RuntimeError(
-                    "Thinning in non-posterior epochs is currently not supported"
-                    "and must be set to 1"
-                )
 
         self._configs.append(config)
 

--- a/liesel/goose/warmup.py
+++ b/liesel/goose/warmup.py
@@ -6,7 +6,7 @@ from functools import partial
 
 from .epoch import EpochConfig, EpochType
 
-_EpochConfig = partial(EpochConfig, thinning=1, optional=None)
+_EpochConfig = partial(EpochConfig, optional=None)
 
 
 def stan_epochs(
@@ -15,21 +15,32 @@ def stan_epochs(
     init_duration: int = 75,
     term_duration: int = 50,
     base_duration: int = 25,
-    thinning: int = 1,
+    thinning_posterior: int = 1,
+    thinning_warmup: int = 1,
 ) -> list[EpochConfig]:
     """
-    Sets up a list of `liesel.goose.epoch.EpochConfig`'s,
-    following the Stan Development Team, [Stan Reference Manual (2021), Chapter 15.2](
+    Sets up a list of `liesel.goose.epoch.EpochConfig`'s, following the Stan
+    Development Team, [Stan Reference Manual (2021), Chapter 15.2](
     https://mc-stan.org/docs/2_28/reference-manual/hmc-algorithm-parameters.html).
 
     ## Parameters
 
     - `warmup_duration`: The number of warmup samples.
     - `posterior_duration`: The number of posterior samples.
-    - `init_duration`: The number of samples in the *initial fast* adaptation epoch.
-    - `term_duration`: The number of samples in the *final fast* adaptation epoch.
-    - `base_duration`: The number of samples in the *first slow* adaptation epoch.
-    - `thinning`: Thinning applied in the posterior epoch.
+    - `init_duration`: The number of samples in the *initial fast* adaptation
+      epoch.
+    - `term_duration`: The number of samples in the *final fast* adaptation
+      epoch.
+    - `base_duration`: The number of samples in the *first slow* adaptation
+      epoch.
+    - `thinning_posterior`: Thinning applied in the posterior epoch.
+    - `thinning_warmup`: Thinning applied in each warmup.
+
+    ## Thinning
+
+    Warning: Kernels which rely on history tuning might not be able to deal with
+    thinning during warmup.
+
     """
 
     if warmup_duration < 20:
@@ -41,19 +52,27 @@ def stan_epochs(
             "(< init_duration + term_duration + base_duration)"
         )
 
-    epochs = [_EpochConfig(EpochType.INITIAL_VALUES, duration=1)]
-    epochs.append(_EpochConfig(EpochType.FAST_ADAPTATION, init_duration))
+    epochs = [_EpochConfig(EpochType.INITIAL_VALUES, duration=1, thinning=1)]
+    epochs.append(
+        _EpochConfig(EpochType.FAST_ADAPTATION, init_duration, thinning_warmup)
+    )
 
     time_left = warmup_duration - init_duration - term_duration
     this_time = base_duration
 
     while 3 * this_time <= time_left:
-        epochs.append(_EpochConfig(EpochType.SLOW_ADAPTATION, this_time))
+        epochs.append(
+            _EpochConfig(EpochType.SLOW_ADAPTATION, this_time, thinning_warmup)
+        )
         time_left -= this_time
         this_time *= 2
 
-    epochs.append(_EpochConfig(EpochType.SLOW_ADAPTATION, time_left))
-    epochs.append(_EpochConfig(EpochType.FAST_ADAPTATION, term_duration))
-    epochs.append(_EpochConfig(EpochType.POSTERIOR, posterior_duration))
+    epochs.append(_EpochConfig(EpochType.SLOW_ADAPTATION, time_left, thinning_warmup))
+    epochs.append(
+        _EpochConfig(EpochType.FAST_ADAPTATION, term_duration, thinning_warmup)
+    )
+    epochs.append(
+        _EpochConfig(EpochType.POSTERIOR, posterior_duration, thinning_posterior)
+    )
 
     return epochs

--- a/tests/goose/test_engine.py
+++ b/tests/goose/test_engine.py
@@ -25,7 +25,7 @@ from liesel.goose.pytree import register_dataclass_as_pytree
 from liesel.goose.types import Array, KeyArray, ModelInterface, ModelState
 from liesel.option import Option
 
-from deterministic_kernels import DetCountingKernel, DetCountingKernelState
+from .deterministic_kernels import DetCountingKernel, DetCountingKernelState
 
 
 @register_dataclass_as_pytree

--- a/tests/goose/test_engine.py
+++ b/tests/goose/test_engine.py
@@ -25,7 +25,7 @@ from liesel.goose.pytree import register_dataclass_as_pytree
 from liesel.goose.types import Array, KeyArray, ModelInterface, ModelState
 from liesel.option import Option
 
-from .deterministic_kernels import DetCountingKernel, DetCountingKernelState
+from deterministic_kernels import DetCountingKernel, DetCountingKernelState
 
 
 @register_dataclass_as_pytree
@@ -152,7 +152,7 @@ def t_test_engine_builder() -> None:
         [
             EpochConfig(EpochType.INITIAL_VALUES, 1, 1, None),
             EpochConfig(EpochType.FAST_ADAPTATION, 50, 1, None),
-            EpochConfig(EpochType.BURNIN, 50, 1, None),
+            EpochConfig(EpochType.BURNIN, 55, 10, None),
             EpochConfig(EpochType.POSTERIOR, 100, 10, None),
         ]
     )
@@ -178,15 +178,15 @@ def t_test_engine_builder() -> None:
 
     # test thinning worked
     assert results.get_posterior_samples()["x"].shape == (4, 10)
-    assert results.get_samples()["x"].shape == (4, 111)
+    assert results.get_samples()["x"].shape == (4, 66)
     assert results.generated_quantities.unwrap().combine_all().unwrap()["foo"].result[
         0
-    ].shape == (4, 111)
+    ].shape == (4, 66)
 
     # test thinning is not applied to TIs
     assert results.transition_infos.combine_all().unwrap()[
         "kernel_01"
-    ].error_code.shape == (4, 200)
+    ].error_code.shape == (4, 205)
 
 
 if __name__ == "__main__":

--- a/tests/goose/test_epoch.py
+++ b/tests/goose/test_epoch.py
@@ -151,9 +151,9 @@ def test_epoch_manager_with_faulty_configs() -> None:
     with pytest.raises(RuntimeError):
         manager.append(EpochConfig(EpochType.INITIAL_VALUES, 1, 1, None))
 
-    # thinning must be one for warmup epoch
+    # thinning must be smaller or equal to duration
     with pytest.raises(RuntimeError):
-        manager.append(EpochConfig(EpochType.FAST_ADAPTATION, 20, 10, None))
+        manager.append(EpochConfig(EpochType.FAST_ADAPTATION, 5, 10, None))
 
     # warm up cannot follow posterior
     manager.append(EpochConfig(EpochType.FAST_ADAPTATION, 3, 1, None))
@@ -173,11 +173,12 @@ def test_epoch_manager_with_faulty_configs() -> None:
 def test_epoch_manager_with_thinning() -> None:
     manager = EpochManager([EpochConfig(EpochType.INITIAL_VALUES, 1, 1, None)])
 
-    # thinning must be one for warmup epoch
+    # thinning must be positive
     with pytest.raises(RuntimeError):
-        manager.append(EpochConfig(EpochType.FAST_ADAPTATION, 20, 10, None))
+        manager.append(EpochConfig(EpochType.FAST_ADAPTATION, 20, -1, None))
 
-    manager.append(EpochConfig(EpochType.FAST_ADAPTATION, 100, 1, None))
+    # thinning can be larger than one in WARMUP
+    manager.append(EpochConfig(EpochType.FAST_ADAPTATION, 100, 10, None))
 
     # thinning can be larger than one in POSTERIOR epoch
     manager.append(EpochConfig(EpochType.POSTERIOR, 100, 20, None))

--- a/tests/goose/test_warmup.py
+++ b/tests/goose/test_warmup.py
@@ -13,3 +13,16 @@ def test_stan_epochs():
 
     assert durations == [1, 75, 25, 50, 100, 200, 500, 50, 1000]
     assert types == [i, f, s, s, s, s, s, f, p]
+
+
+def test_stan_epochs_thinning():
+    epochs = stan_epochs(thinning_posterior=10, thinning_warmup=5)
+    thinning = [epoch.thinning for epoch in epochs]
+    types = [epoch.type for epoch in epochs]
+    i = EpochType.INITIAL_VALUES
+    f = EpochType.FAST_ADAPTATION
+    s = EpochType.SLOW_ADAPTATION
+    p = EpochType.POSTERIOR
+
+    assert thinning == [1, 5, 5, 5, 5, 5, 5, 5, 10]
+    assert types == [i, f, s, s, s, s, s, f, p]


### PR DESCRIPTION
Allows thinning in warm-up epochs. Kernels that request the history, will get a thinned history.