### PR TITLE
Fix layout of multi-faceted plots

### DIFF
--- a/liesel/goose/summary_viz.py
+++ b/liesel/goose/summary_viz.py
@@ -250,7 +250,7 @@ def setup_scatterplot_df(
 def set_plot_cols(plot_df: pd.DataFrame, ncol: int) -> int:
     """Determines number of facets within each row of the grid."""
 
-    num_subparams = plot_df["param"].nunique()
+    num_subparams = plot_df["param_label"].nunique()
     return min(ncol, num_subparams)
 
 


### PR DESCRIPTION
In #3, I overlooked a necessary change in a helper function that controls the number of columns in multi-faceted trace, density, and correlation plots. The number of columns was previously determined by determining the number of unique entries in the "param" column of the helper data frame. Since this information is now located in the "param_label" column, the lookup had to be updated.