### PR TITLE
Fix logging

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -53,9 +53,10 @@ def local_caplog_fn(
     """
     Context manager that captures records from non-propagating loggers.
 
-    After the end of the 'with' statement the log level is restored to its original
-    value. Code adapted from
-    https://github.com/pytest-dev/pytest/issues/3697#issuecomment-790925527
+    After the end of the ``with`` statement, the log level is restored to its original
+    value. Code adapted from `this GitHub comment <GH>`_.
+
+    .. _GH: https://github.com/pytest-dev/pytest/issues/3697#issuecomment-790925527
 
     Parameters
     ----------
@@ -63,19 +64,20 @@ def local_caplog_fn(
         The log level.
     name
         The name of the logger to update.
-
     """
+
     logger = logging.getLogger(name)
 
-    orig_level = logger.level
+    old_level = logger.level
     logger.setLevel(level)
 
     handler = LogCaptureHandler()
     logger.addHandler(handler)
+
     try:
         yield handler
     finally:
-        logger.setLevel(orig_level)
+        logger.setLevel(old_level)
         logger.removeHandler(handler)
 
 
@@ -95,7 +97,8 @@ def local_caplog():
             with local_caplog() as caplog:
                 drb = dr.DistRegBuilder()
                 model = drb.build()
-                assert len(caplog.records)== 1
+                assert len(caplog.records) == 1
                 assert caplog.records[0].levelname == "WARNING"
     """
+
     yield local_caplog_fn

--- a/liesel/__init__.py
+++ b/liesel/__init__.py
@@ -39,10 +39,10 @@ If you are looking for code examples, the [tutorial book][6] might come in handy
 from .__version__ import __version__, __version_info__  # isort: skip  # noqa: F401
 
 from . import goose, liesel, tfp
-from .logging import setup_logger
+from .logging import reset_logger, setup_logger
 
 # because logger setup takes place after importing the submodules, it only affects
 # log messages emitted at runtime
 setup_logger()
 
-__all__ = ["goose", "liesel", "tfp"]
+__all__ = ["goose", "liesel", "tfp", "reset_logger"]

--- a/liesel/logging.py
+++ b/liesel/logging.py
@@ -6,17 +6,36 @@ def setup_logger() -> None:
     """
     Sets up a basic `StreamHandler`, which prints log messages to the terminal.
     The default log level of the `StreamHandler` is set to "info".
+
+    The global logging level for liesel log output can be adjusted like this::
+
+        import logging
+        logger = logging.getLogger("liesel")
+        logger.level = logging.WARNING
+
+    This will set the log level to "warning".
     """
 
-    logger = logging.getLogger("root")
-    logger.setLevel(logging.DEBUG)
+    # We adjust only our library's logger
+    logger = logging.getLogger("liesel")
 
+    # This is the level that will in principle be handled by the logger
+    # If it is set, for example, to logging.WARNING, this logger will never
+    # emit messages of a level below warning.
+    logger.level = logging.DEBUG
+
+    # By setting this to False, we prevent the liesel log messages from being passed
+    # on to the root logger. This prevents duplication of the log messages.
+    logger.propagate = False
+
+    # This is the default handler that we set for our log messages
     ch = logging.StreamHandler()
     ch.setLevel(logging.INFO)
 
     formatter = logging.Formatter("%(levelname)s - %(message)s")
 
     ch.setFormatter(formatter)
+
     logger.addHandler(ch)
 
 

--- a/liesel/logging.py
+++ b/liesel/logging.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 def setup_logger() -> None:
     """
-    Sets up a basic `StreamHandler`, which prints log messages to the terminal.
-    The default log level of the `StreamHandler` is set to "info".
+    Sets up a basic ``StreamHandler`` that prints log messages to the terminal.
+    The default log level of the ``StreamHandler`` is set to "info".
 
-    The global logging level for liesel log output can be adjusted like this::
+    The global log level for Liesel can be adjusted like this::
 
         import logging
         logger = logging.getLogger("liesel")
@@ -19,50 +19,50 @@ def setup_logger() -> None:
     # We adjust only our library's logger
     logger = logging.getLogger("liesel")
 
-    # This is the level that will in principle be handled by the logger
+    # This is the level that will in principle be handled by the logger.
     # If it is set, for example, to logging.WARNING, this logger will never
-    # emit messages of a level below warning.
+    # emit messages of a level below warning
     logger.setLevel(logging.DEBUG)
 
-    # By setting this to False, we prevent the liesel log messages from being passed
-    # on to the root logger. This prevents duplication of the log messages.
+    # By setting this to False, we prevent the Liesel log messages from being passed on
+    # to the root logger. This prevents duplication of the log messages
     logger.propagate = False
 
     # This is the default handler that we set for our log messages
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.INFO)
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
 
     # We define the format of log messages for this handler
     formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
-    ch.setFormatter(formatter)
+    handler.setFormatter(formatter)
 
-    logger.addHandler(ch)
+    logger.addHandler(handler)
 
 
 def reset_logger() -> None:
     """
-    Resets the liesel logger.
+    Resets the Liesel logger.
 
-    Specifically, this function ...
+    Specifically, this function...
 
-    - ... resets the level of the ``"liesel"`` logger to ``logging.NOTSET``.
-    - ... sets ``propagate=True`` for the ``"liesel"`` logger.
-    - ... removes ALL handlers set to the ``"liesel"`` logger.
+    - ... resets the level of the Liesel logger to ``logging.NOTSET``.
+    - ... sets ``propagate=True`` for the Liesel logger.
+    - ... removes *all* handlers from the Liesel logger.
 
     This function is useful if you want to set up a custom logging configuration.
-
     """
+
     # We adjust only our library's logger
     logger = logging.getLogger("liesel")
 
-    # Removes the level of the logger. Thus, this logger will propagate all log records.
+    # Removes the level of the logger. All log messages will be propagated
     logger.setLevel(logging.NOTSET)
 
-    # By setting this to True, we allow the liesel log messages to be passed
-    # on to the root logger.
+    # By setting this to True, we allow the Liesel log messages to be passed on
+    # to the root logger
     logger.propagate = True
 
-    # Removes all handlers from the liesel logger
+    # Removes all handlers from the Liesel logger
     for handler in logger.handlers:
         logger.removeHandler(handler)
 
@@ -74,51 +74,50 @@ def add_file_handler(
     fmt: str = "%(asctime)s - %(levelname)s - %(name)s - %(message)s",
 ) -> None:
     """
-    Adds a file handler for logging output.
+    Adds a file handler to a logger.
 
-    ## Arguments
+    Parameters
+    ----------
+    path
+        Absolute path to the log file. If it does not exist, it will be created.
+        If any parent directory does not exist, it will be created as well.
+    level
+        The log level of the messages to write to the file. Can be ``"debug"``,
+        ``"info"``, ``"warning"``, ``"error"`` or ``"critical"``. The file will
+        contain all messages from the specified level upwards.
+    logger
+        The name of the logger to configure the file handler for. Can be, for example,
+        the full name of a Liesel module. For :mod:`liesel.goose`, the argument should
+        be specified as ``"liesel.goose"``, etc.
+    fmt
+        Formatting string. See the documentation of the :class:`logging.Formatter`.
 
-    - `path`: Absolute path to log file. If it does not exist, it will be created.
-      If any parent directory does not exist, it will be created as well.
-    - `level`: The level of messages to log to the specified file. Can be "debug",
-      "info", "warning", "error" or "critical". The logger will catch all messages
-      from the specified level upwards.
-    - `logger`: The name of the logger to configure the file handler for. Can be,
-      for instance, the full name of a Liesel module. For example, to configure a
-      logger for `liesel.goose`, the logger should be specified as "liesel.goose".
-    - `fmt`: Formatting string, see the documentation of the standard library's
-      `logging.Formatter` class.
+    Examples
+    --------
+    A basic file handler catching all log messages from Liesel::
 
-    ## Examples
+        import logging
+        import liesel as lsl
 
-    A basic file handler, catching all log messages in the Liesel framework:
+        lsl.logging.add_file_handler(path="path/to/logfile.log", level="debug")
 
-    ```python
-    import logging
-    import liesel as lsl
+        logger = logging.getLogger("liesel")
+        logger.warning("My warning message")
 
-    lsl.logging.add_file_handler(path="path/to/logfile.log", level="debug")
+    A file handler that catches only log messages from the :mod:`liesel.goose` module
+    of level "warning" or higher::
 
-    logger = logging.getLogger("liesel")
-    logger.warning("My warning message")
-    ```
+        import logging
+        import liesel as lsl
 
-    A file handler that catches only log messages from the `liesel.goose` module of
-    level "warning" or higher:
+        lsl.logging.add_file_handler(
+            path="path/to/goose_warnings.log",
+            level="warning",
+            logger="liesel.goose"
+        )
 
-    ```python
-    import logging
-    import liesel as lsl
-
-    lsl.logging.add_file_handler(
-        path="path/to/goose_warnings.log",
-        level="warning",
-        logger="liesel.goose"
-    )
-
-    logger = logging.getLogger("liesel")
-    logger.warning("My warning message")
-    ```
+        logger = logging.getLogger("liesel")
+        logger.warning("My warning message")
     """
 
     path = Path(path)
@@ -128,12 +127,12 @@ def add_file_handler(
 
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    log = logging.getLogger(logger)
-    fh = logging.FileHandler(path)
+    _logger = logging.getLogger(logger)
+    handler = logging.FileHandler(path)
 
-    fh.setLevel(getattr(logging, level.upper()))
+    handler.setLevel(getattr(logging, level.upper()))
 
     formatter = logging.Formatter(fmt, "%Y-%m-%d %H:%M:%S")
-    fh.setFormatter(formatter)
+    handler.setFormatter(formatter)
 
-    log.addHandler(fh)
+    _logger.addHandler(handler)

--- a/liesel/logging.py
+++ b/liesel/logging.py
@@ -22,7 +22,7 @@ def setup_logger() -> None:
     # This is the level that will in principle be handled by the logger
     # If it is set, for example, to logging.WARNING, this logger will never
     # emit messages of a level below warning.
-    logger.level = logging.DEBUG
+    logger.setLevel(logging.DEBUG)
 
     # By setting this to False, we prevent the liesel log messages from being passed
     # on to the root logger. This prevents duplication of the log messages.
@@ -37,6 +37,34 @@ def setup_logger() -> None:
     ch.setFormatter(formatter)
 
     logger.addHandler(ch)
+
+
+def reset_logger() -> None:
+    """
+    Resets the liesel logger.
+
+    Specifically, this function ...
+
+    - ... resets the level of the ``"liesel"`` logger to ``logging.NOTSET``.
+    - ... sets ``propagate=True`` for the ``"liesel"`` logger.
+    - ... removes ALL handlers set to the ``"liesel"`` logger.
+
+    This function is useful if you want to set up a custom logging configuration.
+
+    """
+    # We adjust only our library's logger
+    logger = logging.getLogger("liesel")
+
+    # Removes the level of the logger. Thus, this logger will propagate all log records.
+    logger.setLevel(logging.NOTSET)
+
+    # By setting this to True, we allow the liesel log messages to be passed
+    # on to the root logger.
+    logger.propagate = True
+
+    # Removes all handlers from the liesel logger
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
 
 
 def add_file_handler(

--- a/liesel/logging.py
+++ b/liesel/logging.py
@@ -32,8 +32,8 @@ def setup_logger() -> None:
     ch = logging.StreamHandler()
     ch.setLevel(logging.INFO)
 
-    formatter = logging.Formatter("%(levelname)s - %(message)s")
-
+    # We define the format of log messages for this handler
+    formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
     ch.setFormatter(formatter)
 
     logger.addHandler(ch)

--- a/tests/liesel/test_distreg.py
+++ b/tests/liesel/test_distreg.py
@@ -258,11 +258,11 @@ class TestDistRegBuilder:
 
     def test_build_empty(self, local_caplog):
         """An empty model can be built with a warning."""
-        with local_caplog():
+        with local_caplog() as caplog:
             drb = dr.DistRegBuilder()
             model = drb.build()
-            assert len(local_caplog.records) == 1
-            assert local_caplog.records[0].levelname == "WARNING"
+            assert len(caplog.records) == 1
+            assert caplog.records[0].levelname == "WARNING"
             assert model
 
 

--- a/tests/liesel/test_distreg.py
+++ b/tests/liesel/test_distreg.py
@@ -256,13 +256,14 @@ class TestDistRegBuilder:
         with pytest.raises(RuntimeError):
             drb.add_response(y, "Normal")
 
-    def test_build_empty(self, caplog):
+    def test_build_empty(self, local_caplog):
         """An empty model can be built with a warning."""
-        drb = dr.DistRegBuilder()
-        model = drb.build()
-        assert len(caplog.records) == 1
-        assert caplog.records[0].levelname == "WARNING"
-        assert model
+        with local_caplog():
+            drb = dr.DistRegBuilder()
+            model = drb.build()
+            assert len(local_caplog.records) == 1
+            assert local_caplog.records[0].levelname == "WARNING"
+            assert model
 
 
 class TestCopRegBuilder:


### PR DESCRIPTION
This PR fixes the questionable behavior of changing the root logger's settings.

It also adds the current logger's name to the output of Liesel's log messages. This will allow users to identify the exact logger that is responsible for individual messages, such that those exact loggers can be edited more easily.