### PR TITLE
fix quantile-summaries per chain

### DIFF
--- a/liesel/goose/summary_m.py
+++ b/liesel/goose/summary_m.py
@@ -641,9 +641,11 @@ class Summary:
     """
     A summary object.
 
-    Allows easy programmatic access via ``quantities[quantity_name][var_name]``. The
-    array has a similar shape as the parameter with ``var_name``. However, Additionally,
-    for ``hdi`` and ``quantile`` the second dimension refers to the quantile.
+    Allows easy programmatic access via ``quantities[quantity_name][var_name]``.
+    The array has a similar shape as the parameter with ``var_name``. However,
+    if ``per_chain`` is ``True``, and additionally for the quantities ``hdi`` and
+    ``quantile``, the dimensions are different. Please refer to the documentation
+    of the attribute :attr:`.quantities` for details.
 
     The summary object can be turned into a :class:`~pandas.DataFrame` using
     :meth:`.to_dataframe`.


### PR DESCRIPTION
Actually, the ordering of the indices seems to have been correct already. There was a small bug in `Summary.to_dataframe()`.

I did this:

1. Fixed the bug. For this, I had to add `Summary.per_chain` as an instance attribute, because the code in `to_dataframe()` has to work slightly differently depending on whether per_chain is True or False.
2. Added a test checking the bug fix (`test_per_chain_quantiles`)
3. Added a test checking that the indices are in the correct order (`test_quantity_shape`)
4. Added a documentation skeleton for `Summary.quantities`.


This test code...
```python
def test_per_chain_quantiles(result: SamplingResults):
    summary = Summary(result, per_chain=True)
    cols = [
        "var_fqn",
        "chain_index",
        "mean",
        "q_0.05",
        "q_0.5",
        "q_0.95",
        "hdi_low",
        "hdi_high",
    ]
    df = summary.to_dataframe().loc["baz"][cols]
```

... now produces this `df`:

```
         var_fqn  chain_index   mean     q_0.05  q_0.5      q_0.95  hdi_low  hdi_high
variable                                                                             
baz       baz[0]            0  176.5  64.449997  176.5  288.549988     52.0     277.0
baz       baz[1]            1  176.5  64.449997  176.5  288.549988     52.0     277.0
baz       baz[2]            2  176.5  64.449997  176.5  288.549988     52.0     277.0
```