### PR TITLE
Update versions of pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v3.1.0
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
@@ -19,11 +19,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: local

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 import logging
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Generator
 
 import pytest
 from _pytest.logging import LogCaptureHandler

--- a/liesel/experimental/pymc.py
+++ b/liesel/experimental/pymc.py
@@ -74,7 +74,8 @@ distribution argument.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from liesel.goose.types import ModelState, Position
 

--- a/liesel/goose/chain.py
+++ b/liesel/goose/chain.py
@@ -4,7 +4,8 @@ MCMC chains
 This module is experimental. Expect API changes.
 """
 
-from typing import Callable, Generic, Protocol, Sequence, TypeVar
+from collections.abc import Callable, Sequence
+from typing import Generic, Protocol, TypeVar
 
 import jax
 import numpy as np

--- a/liesel/goose/engine.py
+++ b/liesel/goose/engine.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 import logging
 import pickle
 import warnings
+from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import partial
-from typing import NamedTuple, Sequence, cast
+from typing import NamedTuple, cast
 
 import jax
 import jax.lax

--- a/liesel/goose/epoch.py
+++ b/liesel/goose/epoch.py
@@ -4,9 +4,10 @@ MCMC epochs.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Iterable, cast
+from typing import cast
 
 from .pytree import register_dataclass_as_pytree
 from .types import PyTree

--- a/liesel/goose/gibbs.py
+++ b/liesel/goose/gibbs.py
@@ -2,7 +2,8 @@
 Gibbs sampler.
 """
 
-from typing import Callable, ClassVar, Sequence
+from collections.abc import Callable, Sequence
+from typing import ClassVar
 
 from .epoch import EpochState
 from .kernel import (

--- a/liesel/goose/hmc.py
+++ b/liesel/goose/hmc.py
@@ -2,9 +2,10 @@
 Hamiltonian/Hybrid Monte Carlo (HMC).
 """
 
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Callable, ClassVar, Sequence
+from typing import ClassVar
 
 import jax.numpy as jnp
 from blackjax.adaptation.step_size import find_reasonable_step_size

--- a/liesel/goose/iwls.py
+++ b/liesel/goose/iwls.py
@@ -2,8 +2,9 @@
 Iteratively weighted least squares (IWLS) sampler
 """
 
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Callable, ClassVar, Sequence
+from typing import ClassVar
 
 import jax
 import jax.numpy as jnp

--- a/liesel/goose/kernel.py
+++ b/liesel/goose/kernel.py
@@ -3,8 +3,9 @@ Kernel-related info, outcome and mixin classes.
 """
 
 from abc import abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Generic
+from typing import Generic
 
 import jax
 

--- a/liesel/goose/kernel_sequence.py
+++ b/liesel/goose/kernel_sequence.py
@@ -2,8 +2,8 @@
 Kernel sequence.
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Sequence
 
 import jax
 

--- a/liesel/goose/mh_kernel.py
+++ b/liesel/goose/mh_kernel.py
@@ -3,7 +3,8 @@ Metroplis Hastings kernel. This kernel allows for a user-defined proposal functi
 adds the MH step. Optional, the kernel supports a stepsize adaptation.
 """
 
-from typing import Callable, ClassVar, NamedTuple, Sequence
+from collections.abc import Callable, Sequence
+from typing import ClassVar, NamedTuple
 
 import jax
 

--- a/liesel/goose/models.py
+++ b/liesel/goose/models.py
@@ -3,7 +3,7 @@ Model interfaces.
 """
 
 import copy
-from typing import Callable, Sequence
+from collections.abc import Callable, Sequence
 
 from ..docs import usedocs
 from .types import ModelInterface, ModelState, Position

--- a/liesel/goose/nuts.py
+++ b/liesel/goose/nuts.py
@@ -2,9 +2,10 @@
 No U-Turn Sampler (NUTS).
 """
 
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Callable, ClassVar, Sequence
+from typing import ClassVar
 
 import jax.numpy as jnp
 from blackjax.adaptation.step_size import find_reasonable_step_size

--- a/liesel/goose/rw.py
+++ b/liesel/goose/rw.py
@@ -2,8 +2,9 @@
 Random walk sampler.
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import ClassVar, Sequence
+from typing import ClassVar
 
 import jax
 import jax.flatten_util

--- a/liesel/goose/types.py
+++ b/liesel/goose/types.py
@@ -5,7 +5,8 @@ Type aliases, type variables and protocols.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, NewType, Protocol, Sequence, TypeVar
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, NewType, Protocol, TypeVar
 
 if TYPE_CHECKING:
     from .epoch import EpochState

--- a/liesel/liesel/goose.py
+++ b/liesel/liesel/goose.py
@@ -4,8 +4,9 @@ The Liesel-Goose interface.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from functools import reduce
-from typing import TYPE_CHECKING, Callable, Iterable
+from typing import TYPE_CHECKING
 
 from .types import ModelState, Position
 

--- a/liesel/liesel/model.py
+++ b/liesel/liesel/model.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 import logging
 import pickle
 import re
+from collections.abc import Iterable
 from copy import deepcopy
 from functools import reduce
-from typing import Iterable, TypeVar
+from typing import TypeVar
 
 import networkx as nx
 

--- a/liesel/liesel/nodes.py
+++ b/liesel/liesel/nodes.py
@@ -6,18 +6,10 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
 from functools import reduce
 from types import ModuleType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Generic,
-    Iterable,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 import jax
 import jax.numpy as jnp

--- a/liesel/option.py
+++ b/liesel/option.py
@@ -5,7 +5,8 @@ A Rust-inspired Option type for Liesel and Goose.
 from __future__ import annotations
 
 import weakref
-from typing import Callable, Generic, TypeVar
+from collections.abc import Callable
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 U = TypeVar("U")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.isort]
 profile = "black"
+py_version=39
 
 [tool.mypy]
 files = ["liesel", "tests"]

--- a/tests/goose/deterministic_kernels.py
+++ b/tests/goose/deterministic_kernels.py
@@ -1,7 +1,8 @@
 """contains a deterministic kernel used for test purposes"""
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import ClassVar, Sequence
+from typing import ClassVar
 
 import jax.numpy as jnp
 

--- a/tests/goose/kernels/model_lm.py
+++ b/tests/goose/kernels/model_lm.py
@@ -2,7 +2,7 @@
 # Simple linear regression test case
 """
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import jax
 import jax.numpy as jnp

--- a/tests/goose/test_summary_object.py
+++ b/tests/goose/test_summary_object.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import ClassVar, Sequence
+from typing import ClassVar
 
 import jax.numpy as jnp
 import numpy as np


### PR DESCRIPTION
the main change -- and the reason why so many files have been modified -- is that the new version of `isort` replaces a lot of imports from `typing` with imports from `collections.abc` (see https://github.com/asottile/pyupgrade/issues/558). Importing from `typing` is supposedly deprecated since 3.9.