### PR TITLE
Add mutable group object

### DIFF
--- a/liesel/model/__init__.py
+++ b/liesel/model/__init__.py
@@ -26,6 +26,7 @@ from .nodes import (  # TODO: Bijector?
     Data,
     Dist,
     Distribution,
+    Group,
     InputGroup,
     Node,
     NodeState,

--- a/liesel/model/distreg.py
+++ b/liesel/model/distreg.py
@@ -27,7 +27,7 @@ from .legacy import (
     SmoothingParam,
 )
 from .model import GraphBuilder, Model
-from .nodes import Array, Bijector, Dist, Distribution, Node, Var
+from .nodes import Array, Bijector, Dist, Distribution, Group, Node, Var
 
 matrix_rank = np.linalg.matrix_rank
 
@@ -78,7 +78,7 @@ class DistRegBuilder(GraphBuilder):
         s: float,
         predictor: str,
         name: str | None = None,
-    ) -> dict[str, Var]:
+    ) -> Group:
         """
         Adds a parametric smooth to the model builder.
 
@@ -114,15 +114,9 @@ class DistRegBuilder(GraphBuilder):
         smooth_var = Smooth(X_var, beta_var, name=name)
         self._smooths[predictor].append(smooth_var)
 
-        group = {
-            "smooth": smooth_var,
-            "beta": beta_var,
-            "X": X_var,
-            "m": m_var,
-            "s": s_var,
-        }
+        group = Group(name, smooth=smooth_var, beta=beta_var, X=X_var, m=m_var, s=s_var)
 
-        self.add_group(name, **group)
+        self.add_groups(group)
         return group
 
     def add_np_smooth(
@@ -133,7 +127,7 @@ class DistRegBuilder(GraphBuilder):
         b: float,
         predictor: str,
         name: str | None = None,
-    ) -> dict[str, Var]:
+    ) -> Group:
         """
         Adds a non-parametric smooth to the model builder.
 
@@ -183,18 +177,19 @@ class DistRegBuilder(GraphBuilder):
         smooth_var = Smooth(X_var, beta_var, name=name)
         self._smooths[predictor].append(smooth_var)
 
-        group = {
-            "smooth": smooth_var,
-            "beta": beta_var,
-            "tau2": tau2_var,
-            "rank": rank_var,
-            "X": X_var,
-            "K": K_var,
-            "a": a_var,
-            "b": b_var,
-        }
+        group = Group(
+            name,
+            smooth=smooth_var,
+            beta=beta_var,
+            tau2=tau2_var,
+            rank=rank_var,
+            X=X_var,
+            K=K_var,
+            a=a_var,
+            b=b_var,
+        )
 
-        self.add_group(name, **group)
+        self.add_groups(group)
         return group
 
     def add_predictor(self, name: str, inverse_link: type[Bijector]) -> DistRegBuilder:

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -776,7 +776,7 @@ class Model:
         self._auto_update = auto_update
 
     def groups(self) -> dict[str, Group]:
-        """Composes the groups defined in the model nodes and variables."""
+        """Collects the groups in the model's nodes and variables."""
         node_group_dicts = [n.groups for n in self._nodes.values() if n.groups]
         var_group_dicts = [v.groups for v in self._vars.values() if v.groups]
         dictlist = node_group_dicts + var_group_dicts

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import weakref
 from abc import ABC, abstractmethod
+from collections import UserDict
 from collections.abc import Callable
 from functools import wraps
 from types import MappingProxyType
@@ -15,6 +16,7 @@ import tensorflow_probability.substrates.jax.bijectors as jb
 import tensorflow_probability.substrates.jax.distributions as jd
 import tensorflow_probability.substrates.numpy.bijectors as nb
 import tensorflow_probability.substrates.numpy.distributions as nd
+from deprecated.sphinx import deprecated
 
 from ..distributions.nodist import NoDistribution
 
@@ -122,7 +124,7 @@ class Node(ABC):
         _needs_seed: bool = False,
         **kwinputs: Any,
     ):
-        self._groups: set[tuple[str, str]] = set()
+        self._groups: _GroupDict = _GroupDict(self)
         self._inputs = tuple(self._to_node(_input) for _input in inputs)
         self._kwinputs = {kw: self._to_node(_input) for kw, _input in kwinputs.items()}
         self._kwinputs_proxy = MappingProxyType(self._kwinputs)
@@ -202,23 +204,11 @@ class Node(ABC):
         return self
 
     @property
-    def groups(self) -> set[tuple[str, str]]:
+    def groups(self) -> _GroupDict:
         """
         The groups the node is part of.
-
-        The groups are defined as a set of tuples, each of which consists of
-        the group name and the key of the node in the group, e.g.::
-
-            {
-                ("group1", "key_in_group1"),
-                ("group2", "key_in_group2"),
-            }
         """
         return self._groups
-
-    @groups.setter
-    def groups(self, groups: set[tuple[str, str]]):
-        self._groups = groups
 
     @property
     def inputs(self) -> tuple[Node, ...]:
@@ -678,7 +668,7 @@ class Var:
         self._parameter = False
         self._role = ""
 
-        self._groups: set[tuple[str, str]] = set()
+        self._groups: _GroupDict = _GroupDict(self)
 
         self.info: dict[str, Any] = {}
         """Additional meta-information about the variable as a dict."""
@@ -771,23 +761,9 @@ class Var:
         self._dist_node = dist_node
 
     @property
-    def groups(self) -> set[tuple[str, str]]:
-        """
-        The groups the variable belongs to.
-
-        The groups are defined as a set of tuples, each of which consists of
-        the group name and the key of the variable in the group, e.g.::
-
-            {
-                ("group1", "key_in_group1"),
-                ("group2", "key_in_group2"),
-            }
-        """
+    def groups(self) -> _GroupDict:
+        """The groups the variable belongs to."""
         return self._groups
-
-    @groups.setter
-    def groups(self, groups: set[tuple[str, str]]):
-        self._groups = groups
 
     @property
     def has_dist(self) -> bool:
@@ -961,7 +937,8 @@ def Param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-def add_group(name: str, **kwargs: Node | Var) -> None:
+@deprecated(reason="Use the new `Group` object directly.", version="0.2.2")
+def add_group(name: str, **kwargs: Node | Var) -> Group:
     """
     Assigns the nodes and variables to a group.
 
@@ -976,5 +953,230 @@ def add_group(name: str, **kwargs: Node | Var) -> None:
         as keywords.
     """
 
-    for key, arg in kwargs.items():
-        arg.groups.add((name, key))
+    return Group(name, **kwargs)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Group ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+class _GroupDict(UserDict):
+    """
+    A modified dictionary that holds :class:`.Group` objects.
+    """
+
+    def __init__(self, parent: Node | Var, **groups):
+        self._parent = parent
+        super().__init__(**groups)
+
+    def __setitem__(self, key: str, item: Group) -> None:
+
+        if not isinstance(item, Group):
+            raise ValueError(f"{item} is not a Group.")
+
+        if key != item.name:
+            raise RuntimeError(
+                f"Key '{key}' is not equal to group name: '{item.name}'."
+            )
+
+        if key in self.data:
+            raise RuntimeError(
+                f"{self._parent} is already a member of a group with the name {key}."
+            )
+
+        if self._parent not in item.values():
+            raise RuntimeError(f"{self} is not a member of {item}.")
+
+        return super().__setitem__(key, item)
+
+    def __delitem__(self, key: str) -> None:
+        group = self.data[key]
+        name_in_group = group.name_of(self._parent)
+        if name_in_group is not None:
+            del group[name_in_group]
+
+    def _remove(self, key: str) -> None:
+        del self.data[key]
+
+
+class Group(UserDict):
+    """
+    A modified dictionary that holds :class:`.Var` and :class:`.Node` objects.
+
+    The keys for the group members can differ from their ``.name`` attribute.
+
+    Parameters
+    ----------
+    name
+        Group name. When working with groups, you should make sure that your group names
+        are unique.
+    **nodes_and_vars
+        :class:`.Var` and :class:`.Node` objects that become members of this group. In
+        the group, vars and nodes will be referred to by the key that you use here. This
+        key is allowed to differ from the vars' and nodes' names.
+
+    Examples
+    --------
+
+    Add two vars to a group upon initialization::
+
+        >>> import liesel.model as lsl
+
+        >>> v1 = lsl.Var(0.0, name="v1")
+        >>> v2 = lsl.Var(0.0, name="v2")
+        >>> group = lsl.Group("g1", var1=v1, var2=v2)
+        >>> group.vars
+        mappingproxy({'var1': Var<v1>, 'var2': Var<v2>})
+
+
+    Add a var to a group after initialization::
+
+        >>> import liesel.model as lsl
+
+        >>> v1 = lslVar(0.0, name="v1")
+        >>> group = Group("g1")
+        >>> group["var1"] = v1
+        >>> group.vars
+        mappingproxy({'var1': Var<v1>})
+
+    Remove var from a group. This ends the group membership of the variable, i.e.: the
+    var is removed from the group AND the group is removed from the var::
+
+        >>> import liesel.model as lsl
+
+        >>> v1 = lslVar(0.0, name="v1")
+        >>> group = Group("g1", var1=v1)
+
+        >>> del group["var1"]
+        >>> group.vars
+        mappingproxy({})
+        >>> v1.groups
+        {}
+
+    Remove group from var. This also ends the group membership of the variable, i.e.:
+    the var is removed from the group AND the group is removed from the var::
+
+        >>> import liesel.model as lsl
+
+        >>> v1 = lslVar(0.0, name="v1")
+        >>> group = Group("g1", var1=v1)
+
+        >>> del v1.groups["g1"]
+        >>> v1.groups
+        {}
+        >>> g1.vars
+        mappingproxy({})
+
+    Create a new group that merges two groups::
+
+        >>> import liesel.model as lsl
+
+        >>> v1 = lslVar(0.0, name="v1")
+        >>> v2 = lslVar(0.0, name="v2")
+
+        >>> group1 = Group("g1", var1=v1)
+        >>> group2 = Group("g2", var2=v2)
+
+        >>> group3 = Group("g3", **group1, **group2)
+        >>> group3.vars
+        mappingproxy({'var1': Var<v1>, 'var2': Var<v2>})
+
+    Merge a group into an existing group::
+
+        >>> import liesel.model as lsl
+
+        >>> v1 = lslVar(0.0, name="v1")
+        >>> v2 = lslVar(0.0, name="v2")
+
+        >>> group1 = Group("g1", var1=v1)
+        >>> group2 = Group("g2", var2=v2)
+
+        >>> group1 |= group2
+        >>> group1.vars
+        mappingproxy({'var1': Var<v1>, 'var2': Var<v2>})
+    """
+
+    def __init__(self, name: str, **nodes_and_vars):
+        self.name = name
+        super().__init__(**nodes_and_vars)
+
+    def __setitem__(self, key: str, obj: Var | Node):
+        """
+        Implements: ``self[key] = obj``
+
+        Replaces existing nodes or variables of the same name.
+        Fails, if the Var/Node is already a member of this group or a group with the
+        same name, or if membership is inconsistent.
+        """
+        obj_in_group = obj in self.data.values()
+        group_in_obj = self in obj.groups.values()
+
+        if obj_in_group and group_in_obj:
+            raise RuntimeError(f"{obj} is already part of {self}.")
+
+        elif obj_in_group or group_in_obj:
+            raise RuntimeError(
+                f"Inconsistent group membership for {obj}. {obj} in {self}:"
+                f" {obj_in_group}; {self} in {obj}.groups:"
+                f" {group_in_obj}."
+            )
+
+        elif self.name in obj.groups:
+            raise RuntimeError(
+                f"{obj} is already a member of a group with the name '{self.name}'."
+            )
+
+        if key in self.data:
+            self.__delitem__(key)
+
+        self.data[key] = obj
+        obj.groups[self.name] = self
+
+    def __delitem__(self, key: str):
+        """
+        Implements: ``del self[key]``
+        """
+        obj = self.__getitem__(key)
+        obj.groups._remove(self.name)
+
+        del self.data[key]
+
+    def __or__(self, other):
+        """
+        Forbid the '|' operator for groups, because it may be confusing that the new
+        object is a dict, not a group.
+        """
+        raise NotImplementedError(
+            "New groups cannot be created with the '|' operator, because they need a"
+            " new name."
+        )
+
+    def __ior__(self, other) -> Group:
+        """
+        Implements: ``self |= other``
+        """
+        self.update(other)
+        return self
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}<{self.name}>"
+
+    @property
+    def vars(self) -> MappingProxyType[str, Var]:
+        """A mapping of the variables in the group with their names as keys."""
+
+        vars_ = {name: obj for name, obj in self.data.items() if isinstance(obj, Var)}
+        return MappingProxyType(vars_)
+
+    @property
+    def nodes(self) -> MappingProxyType[str, Node]:
+        """A mapping of the nodes in the group with their names as keys."""
+        nodes = {name: obj for name, obj in self.data.items() if isinstance(obj, Node)}
+        return MappingProxyType(nodes)
+
+    def name_of(self, item: Node | Var) -> str | None:
+        for key, member in self.data.items():
+            if member is item:
+                return key
+        return None

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -966,7 +966,7 @@ class _GroupDict(UserDict):
     A modified dictionary that holds :class:`.Group` objects.
     """
 
-    def __init__(self, parent: Node | Var, **groups):
+    def __init__(self, parent: Node | Var, **groups) -> None:
         self._parent = parent
         super().__init__(**groups)
 
@@ -1097,11 +1097,11 @@ class Group(UserDict):
         mappingproxy({'var1': Var<v1>, 'var2': Var<v2>})
     """
 
-    def __init__(self, name: str, **nodes_and_vars):
+    def __init__(self, name: str, **nodes_and_vars) -> None:
         self.name = name
         super().__init__(**nodes_and_vars)
 
-    def __setitem__(self, key: str, obj: Var | Node):
+    def __setitem__(self, key: str, obj: Var | Node) -> None:
         """
         Implements: ``self[key] = obj``
 
@@ -1133,7 +1133,7 @@ class Group(UserDict):
         self.data[key] = obj
         obj.groups[self.name] = self
 
-    def __delitem__(self, key: str):
+    def __delitem__(self, key: str) -> None:
         """
         Implements: ``del self[key]``
         """

--- a/tests/model/test_graph_builder.py
+++ b/tests/model/test_graph_builder.py
@@ -294,3 +294,19 @@ def test_transform_weak() -> None:
     assert var.weak
     with pytest.raises(RuntimeError):
         lmodel.GraphBuilder().transform(var)
+
+
+def test_groups() -> None:
+    v1 = lnodes.Var(0.0, name="v1")
+    g1 = lnodes.Group("g1", var1=v1)
+    gb = lmodel.GraphBuilder().add_groups(g1)
+    assert v1 in gb.vars
+
+
+def test_add_group_with_duplicate_name() -> None:
+    v1 = lnodes.Var(0.0, name="v1")
+    v2 = lnodes.Var(0.0, name="v2")
+    g1 = lnodes.Group("g1", var1=v1)
+    g2 = lnodes.Group("g1", var1=v2)
+    with pytest.raises(RuntimeError):
+        lmodel.GraphBuilder().add_groups(g1, g2)

--- a/tests/model/test_group.py
+++ b/tests/model/test_group.py
@@ -1,0 +1,304 @@
+import pytest
+
+from liesel.model import Data, Group, Var
+
+
+class TestGroup:
+    def test_init(self):
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+
+        g = Group("test", var1=v1, var2=v2)
+
+        assert "var1" in g
+        assert "var2" in g
+        assert g.name in v1.groups
+        assert g.name in v2.groups
+
+    def test_setitem(self):
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+
+        g = Group("test")
+        g["var1"] = v1
+        g["var2"] = v2
+
+        assert g.name in v1.groups
+        assert g.name in v2.groups
+
+    def test_delitem(self):
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+
+        g = Group("test", var1=v1, var2=v2)
+
+        del g["var1"]
+
+        assert "var1" not in g
+        assert g.name not in v1.groups
+        assert g.name in v2.groups
+
+    def test_pop(self):
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+
+        g = Group("test", var1=v1, var2=v2)
+
+        g.pop("var1")
+
+        assert "var1" not in g
+        assert g.name not in v1.groups
+        assert g.name in v2.groups
+
+    def test_clear(self):
+
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+
+        g = Group("test", var1=v1, var2=v2)
+        g.clear()
+
+        assert not g.data
+
+        assert g.name not in v1.groups
+        assert g.name not in v2.groups
+
+    def test_update(self):
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+
+        g = Group("test")
+        g.update({"var1": v1, "var2": v2})
+
+        assert g.name in v1.groups
+        assert g.name in v2.groups
+
+    def test_vars(self):
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+        n1 = Data(0.0)
+
+        g = Group("test", var1=v1, var2=v2, nd1=n1)
+
+        assert len(g.vars) == 2
+        assert "var1" in g.vars
+        assert "var2" in g.vars
+
+    def test_nodes(self):
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+        n1 = Data(0.0)
+
+        g = Group("test", var1=v1, var2=v2, nd1=n1)
+
+        assert len(g.nodes) == 1
+        assert "nd1" in g.nodes
+
+    def test_merge_operator(self):
+        """
+        Merging with the ``|`` operator does fails, because new groups need new names.
+        """
+
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+        n1 = Data(0.0)
+
+        g1 = Group("g1", var1=v1, var2=v2)
+        g2 = Group("g2", nd1=n1)
+
+        with pytest.raises(NotImplementedError):
+            g1 | g2
+
+    def test_update_inplace(self):
+        """
+        Merging inplace seems nice at first, but the new group membership of the
+        members of group 2 is not updated in their respective .groups attribute.
+        """
+
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+        n1 = Data(0.0)
+
+        g1 = Group("g1", var1=v1, var2=v2)
+        g2 = Group("g2", nd1=n1)
+
+        g1 |= g2
+
+        assert g1.name == "g1"  # name of g1 remains unchanged
+
+        # group 1 gets updated
+        assert len(g1) == 3
+        assert "nd1" in g1
+
+        # node gets updated
+        assert len(n1.groups) == 2
+        assert g1.name in n1.groups
+
+    def test_merge_upacking(self):
+        """
+        Merging with unpacking works, but the new dict is not a group.
+        """
+
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+        n1 = Data(0.0)
+
+        g1 = Group("g1", var1=v1, var2=v2)
+        g2 = Group("g2", nd1=n1)
+
+        g3 = {**g1, **g2}
+
+        with pytest.raises(AttributeError):
+            g3.name
+        assert not isinstance(g3, Group)
+        assert len(g3) == 3
+        assert "nd1" in g3
+
+    def test_merge_unpack_second(self):
+        """This seems to be nice and explicit, things happen as expected."""
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+        n1 = Data(0.0)
+
+        g1 = Group("g1", var1=v1, var2=v2)
+        g2 = Group("g2", nd1=n1)
+
+        g3 = Group("g3", **g1, **g2)
+
+        assert len(g3) == 3
+        assert "nd1" in g3
+        assert len(v1.groups) == 2
+
+    def test_merge_update(self):
+        """This seems to be nice and explicit, things happen as expected."""
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+        n1 = Data(0.0)
+
+        g1 = Group("g1", var1=v1, var2=v2)
+        g2 = Group("g2", nd1=n1)
+
+        g1.update(g2)
+
+        assert g1.name == "g1"  # name of g1 remains unchanged
+
+        # g1 gets updated
+        assert len(g1) == 3
+        assert "nd1" in g1
+
+        # node gets updated
+        assert g1.name in n1.groups
+        assert len(n1.groups) == 2
+
+        # members of g1 remain unchanged
+        assert len(v1.groups) == 1
+
+    def test_replace(self):
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+
+        g1 = Group("g1", var1=v1)
+        g1["var1"] = v2
+
+        # g1 gets updated
+        assert len(g1) == 1
+
+        assert v1 not in g1.values()
+        assert v2 in g1.values()
+
+        assert g1.name not in v1.groups
+        assert not v1.groups
+
+        assert g1.name in v2.groups
+
+    def test_double_membership(self):
+        """Each node can only be member of the same group once."""
+        v1 = Var(0.0, name="v1")
+        g1 = Group("g1", var1=v1)
+        with pytest.raises(RuntimeError):
+            g1["var2"] = v1
+
+    def test_duplicate_name(self):
+        """A node cannot be member of two groups with the same name."""
+        v1 = Var(0.0, name="v1")
+        g1 = Group("g1")
+        g2 = Group("g1")
+
+        g1["var1"] = v1
+        with pytest.raises(RuntimeError):
+            g2["var_name"] = v1
+
+    def test_inconsistent_membership(self):
+        """
+        As a safeguard, there is an error if group membership is inconsistent.
+        """
+        # SCENARIO 1: Node loses information about group membershio
+        v1 = Var(0.0, name="v1")
+        g1 = Group("g1", var1=v1)
+
+        # remove group from .groups dict without terminating group membership
+        del v1.groups.data["g1"]
+
+        assert "var1" in g1
+        assert v1 in g1.values()
+        assert "g1" not in v1.groups
+
+        with pytest.raises(RuntimeError):
+            g1["var1"] = v1
+
+        # SCENARIO 2: Group loses information about node membershio
+        v1 = Var(0.0, name="v1")
+        g1 = Group("g1", var1=v1)
+
+        # remove group from .groups dict without terminating group membership
+        del g1.data["var1"]
+
+        assert "var1" not in g1
+        assert v1 not in g1.values()
+        assert "g1" in v1.groups
+
+        with pytest.raises(RuntimeError):
+            g1["var1"] = v1
+
+
+class TestGroupDict:
+    def test_only_groups_allowed(self):
+        v1 = Var(0.0, name="v1")
+        with pytest.raises(ValueError, match="not a Group"):
+            v1.groups["test"] = "string"
+
+    def test_add_group_under_wrong_name(self):
+        """The key in GroupDict attribute must be equal to the group.name attribute."""
+        v1 = Var(0.0, name="v1")
+        g1 = Group("g1")
+        g1.data["var1"] = v1  # workaround for membership without updating the node
+        with pytest.raises(RuntimeError, match="not equal to group name"):
+            v1.groups["g2"] = g1
+
+    def test_add_group_without_membership_fails(self):
+        v1 = Var(0.0, name="v1")
+        g1 = Group("g1")
+        with pytest.raises(RuntimeError, match="not a member"):
+            v1.groups["g1"] = g1
+
+    def test_remove_group(self):
+        """
+        When you remove a group from the GroupDict, membership data within the group
+        is also updated, i.e. the node is no member of the group anymore.
+        """
+        v1 = Var(0.0, name="v1")
+        g1 = Group("g1", var1=v1)
+
+        del v1.groups["g1"]
+        assert "var1" not in g1
+        assert "g1" not in v1.groups
+
+    def test_replace_fails(self):
+        """You cannot simply replace a group."""
+        v1 = Var(0.0, name="v1")
+        Group("g1", var1=v1)
+
+        with pytest.raises(
+            RuntimeError, match="already a member of a group with the name"
+        ):
+            v1.groups["g1"] = Group("g1")

--- a/tests/model/test_group.py
+++ b/tests/model/test_group.py
@@ -4,7 +4,7 @@ from liesel.model import Data, Group, Var
 
 
 class TestGroup:
-    def test_init(self):
+    def test_init(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
 
@@ -15,7 +15,7 @@ class TestGroup:
         assert g.name in v1.groups
         assert g.name in v2.groups
 
-    def test_setitem(self):
+    def test_setitem(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
 
@@ -26,7 +26,7 @@ class TestGroup:
         assert g.name in v1.groups
         assert g.name in v2.groups
 
-    def test_delitem(self):
+    def test_delitem(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
 
@@ -38,7 +38,7 @@ class TestGroup:
         assert g.name not in v1.groups
         assert g.name in v2.groups
 
-    def test_pop(self):
+    def test_pop(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
 
@@ -50,7 +50,7 @@ class TestGroup:
         assert g.name not in v1.groups
         assert g.name in v2.groups
 
-    def test_clear(self):
+    def test_clear(self) -> None:
 
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
@@ -63,7 +63,7 @@ class TestGroup:
         assert g.name not in v1.groups
         assert g.name not in v2.groups
 
-    def test_update(self):
+    def test_update(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
 
@@ -73,7 +73,7 @@ class TestGroup:
         assert g.name in v1.groups
         assert g.name in v2.groups
 
-    def test_vars(self):
+    def test_vars(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
         n1 = Data(0.0)
@@ -84,7 +84,7 @@ class TestGroup:
         assert "var1" in g.vars
         assert "var2" in g.vars
 
-    def test_nodes(self):
+    def test_nodes(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
         n1 = Data(0.0)
@@ -94,7 +94,7 @@ class TestGroup:
         assert len(g.nodes) == 1
         assert "nd1" in g.nodes
 
-    def test_merge_operator(self):
+    def test_merge_operator(self) -> None:
         """
         Merging with the ``|`` operator does fails, because new groups need new names.
         """
@@ -109,7 +109,7 @@ class TestGroup:
         with pytest.raises(NotImplementedError):
             g1 | g2
 
-    def test_update_inplace(self):
+    def test_update_inplace(self) -> None:
         """
         Merging inplace seems nice at first, but the new group membership of the
         members of group 2 is not updated in their respective .groups attribute.
@@ -134,7 +134,7 @@ class TestGroup:
         assert len(n1.groups) == 2
         assert g1.name in n1.groups
 
-    def test_merge_upacking(self):
+    def test_merge_upacking(self) -> None:
         """
         Merging with unpacking works, but the new dict is not a group.
         """
@@ -149,12 +149,12 @@ class TestGroup:
         g3 = {**g1, **g2}
 
         with pytest.raises(AttributeError):
-            g3.name
+            g3.name  # type: ignore
         assert not isinstance(g3, Group)
         assert len(g3) == 3
         assert "nd1" in g3
 
-    def test_merge_unpack_second(self):
+    def test_merge_unpack_second(self) -> None:
         """This seems to be nice and explicit, things happen as expected."""
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
@@ -169,7 +169,7 @@ class TestGroup:
         assert "nd1" in g3
         assert len(v1.groups) == 2
 
-    def test_merge_update(self):
+    def test_merge_update(self) -> None:
         """This seems to be nice and explicit, things happen as expected."""
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
@@ -193,7 +193,7 @@ class TestGroup:
         # members of g1 remain unchanged
         assert len(v1.groups) == 1
 
-    def test_replace(self):
+    def test_replace(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
 
@@ -211,14 +211,14 @@ class TestGroup:
 
         assert g1.name in v2.groups
 
-    def test_double_membership(self):
+    def test_double_membership(self) -> None:
         """Each node can only be member of the same group once."""
         v1 = Var(0.0, name="v1")
         g1 = Group("g1", var1=v1)
         with pytest.raises(RuntimeError):
             g1["var2"] = v1
 
-    def test_duplicate_name(self):
+    def test_duplicate_name(self) -> None:
         """A node cannot be member of two groups with the same name."""
         v1 = Var(0.0, name="v1")
         g1 = Group("g1")
@@ -228,7 +228,7 @@ class TestGroup:
         with pytest.raises(RuntimeError):
             g2["var_name"] = v1
 
-    def test_inconsistent_membership(self):
+    def test_inconsistent_membership(self) -> None:
         """
         As a safeguard, there is an error if group membership is inconsistent.
         """
@@ -262,12 +262,12 @@ class TestGroup:
 
 
 class TestGroupDict:
-    def test_only_groups_allowed(self):
+    def test_only_groups_allowed(self) -> None:
         v1 = Var(0.0, name="v1")
         with pytest.raises(ValueError, match="not a Group"):
-            v1.groups["test"] = "string"
+            v1.groups["test"] = "string"  # type: ignore
 
-    def test_add_group_under_wrong_name(self):
+    def test_add_group_under_wrong_name(self) -> None:
         """The key in GroupDict attribute must be equal to the group.name attribute."""
         v1 = Var(0.0, name="v1")
         g1 = Group("g1")
@@ -275,13 +275,13 @@ class TestGroupDict:
         with pytest.raises(RuntimeError, match="not equal to group name"):
             v1.groups["g2"] = g1
 
-    def test_add_group_without_membership_fails(self):
+    def test_add_group_without_membership_fails(self) -> None:
         v1 = Var(0.0, name="v1")
         g1 = Group("g1")
         with pytest.raises(RuntimeError, match="not a member"):
             v1.groups["g1"] = g1
 
-    def test_remove_group(self):
+    def test_remove_group(self) -> None:
         """
         When you remove a group from the GroupDict, membership data within the group
         is also updated, i.e. the node is no member of the group anymore.
@@ -293,7 +293,7 @@ class TestGroupDict:
         assert "var1" not in g1
         assert "g1" not in v1.groups
 
-    def test_replace_fails(self):
+    def test_replace_fails(self) -> None:
         """You cannot simply replace a group."""
         v1 = Var(0.0, name="v1")
         Group("g1", var1=v1)

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -90,21 +90,6 @@ def test_parameter() -> None:
         var.parameter = False
 
 
-def test_groups() -> None:
-    var = lnodes.Var(0.0, None)
-
-    assert not var.groups
-
-    grp = {
-        ("grp", "role"),
-    }
-    var.groups = grp
-    assert var.groups is grp
-
-    _ = lmodel.Model([var])
-    var.groups = set()
-
-
 def test_info() -> None:
     var = lnodes.Var(0.0, None)
 


### PR DESCRIPTION
This PR holds my proposal for a `lsl.Group` object.

## How to use the `Group` object

Add two vars to a group upon initialization::

```python
>>> import liesel.model as lsl

>>> v1 = lsl.Var(0.0, name="v1")
>>> v2 = lsl.Var(0.0, name="v2")
>>> group = lsl.Group("g1", var1=v1, var2=v2)
>>> group.vars
mappingproxy({'var1': Var<v1>, 'var2': Var<v2>})
``` 

Add a var to a group after initialization::

```python
>>> import liesel.model as lsl

>>> v1 = lsl.Var(0.0, name="v1")
>>> group = lsl.Group("g1")
>>> group["var1"] = v1
>>> group.vars
mappingproxy({'var1': Var<v1>})
```

Remove var from a group. This ends the group membership of the variable, i.e.: the var is removed from the group AND the group is removed from the var::

```python
>>> import liesel.model as lsl

>>> v1 = lsl.Var(0.0, name="v1")
>>> group = lsl.Group("g1", var1=v1)

>>> del group["var1"]
>>> group.vars
mappingproxy({})
>>> v1.groups
{}
```

Remove group from var. This also ends the group membership of the variable, i.e.: the var is removed from the group AND the group is removed from the var::


```python
>>> import liesel.model as lsl

>>> v1 = lsl.Var(0.0, name="v1")
>>> group = lsl.Group("g1", var1=v1)

>>> del v1.groups["g1"]
>>> v1.groups
{}
>>> g1.vars
mappingproxy({})
```

Create a new group that merges two groups::

```python
>>> import liesel.model as lsl

>>> v1 = lsl.Var(0.0, name="v1")
>>> v2 = lsl.Var(0.0, name="v2")

>>> group1 = lsl.Group("g1", var1=v1)
>>> group2 = lsl.Group("g2", var2=v2)

>>> group3 = lsl.Group("g3", **group1, **group2)
>>> group3.vars
mappingproxy({'var1': Var<v1>, 'var2': Var<v2>})
```

Merge a group into an existing group::

```python
>>> import liesel.model as lsl

>>> v1 = lsl.Var(0.0, name="v1")
>>> v2 = lsl.Var(0.0, name="v2")

>>> group1 = lsl.Group("g1", var1=v1)
>>> group2 = lsl.Group("g2", var2=v2)

>>> group1 |= group2
>>> group1.vars
mappingproxy({'var1': Var<v1>, 'var2': Var<v2>})
```

## Other changes

- `Node.groups` and `Var.groups` are now basically a modified dictionary of groups, indexed by their names. It is modified to prevent user errors. For example, you cannot add groups to it, if the node/var is not a member of that group. And you cannot simply override existing groups with the same name - to do that, you first have to remove the node/var from the existing node.
- The changed allowed `Model.groups()` to be simplified a bit. It (still) returns a dictionary of all groups in the model. Note that this method will use ordinary dictionary merging. That means it will not complain if there are different groups with the same name - but only one of those will be included in the dictionary in the end. This mirrors the previous behavior, I think. I did not change that, because I am not sure whether it is really important to have a check here.
- `GraphBuilder.groups()` is new and does the same as `Model.groups()`
- `GraphBuilder.add_group()` becomes `GraphBuilder.add_groups()`. It takes a variable number of groups and adds their members to the graph. Before, it created the groups, now the groups are created on their own. This method checks for name uniqueness against the existing groups obtained from `GraphBuilder.groups()`. It also checks that the entered groups have unique names.