### PR TITLE
Improve uniqueness checks for group names

### DIFF
--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -673,18 +673,32 @@ class Model:
             nodes_and_vars = [*model.nodes.values(), *model.vars.values()]
             model.pop_nodes_and_vars()
 
-        groups = {g for nv in nodes_and_vars for g in nv.groups.values()}
-        self._nodes = {nv.name: nv for nv in nodes_and_vars if isinstance(nv, Node)}
-        self._vars = {nv.name: nv for nv in nodes_and_vars if isinstance(nv, Var)}
+        nodes = [nv for nv in nodes_and_vars if isinstance(nv, Node)]
+        nodes = list(dict.fromkeys(nodes).keys())
+        counts = Counter(n.name for n in nodes)
+        dups = [k for k, v in counts.items() if v > 1]
 
-        if len({g.name for g in groups}) < len(groups):
-            raise RuntimeError("Model received groups with duplicate names")
+        if dups:
+            raise RuntimeError(f"Duplicate node names: {', '.join(dups)}")
 
-        if len(self._nodes) < sum(isinstance(nv, Node) for nv in nodes_and_vars):
-            raise RuntimeError("Model received nodes with duplicate names")
+        _vars = [nv for nv in nodes_and_vars if isinstance(nv, Var)]
+        _vars = list(dict.fromkeys(_vars).keys())
+        counts = Counter(v.name for v in _vars)
+        dups = [k for k, v in counts.items() if v > 1]
 
-        if len(self._vars) < sum(isinstance(nv, Var) for nv in nodes_and_vars):
-            raise RuntimeError("Model received vars with duplicate names")
+        if dups:
+            raise RuntimeError(f"Duplicate variable names: {', '.join(dups)}")
+
+        groups = [g for nv in nodes_and_vars for g in nv.groups.values()]
+        groups = list(dict.fromkeys(groups).keys())
+        counts = Counter(g.name for g in groups)
+        dups = [k for k, v in counts.items() if v > 1]
+
+        if dups:
+            raise RuntimeError(f"Duplicate group names: {', '.join(dups)}")
+
+        self._nodes = {n.name: n for n in nodes}
+        self._vars = {v.name: v for v in _vars}
 
         if copy:
             self._nodes, self._vars = deepcopy((self._nodes, self._vars))

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -248,28 +248,26 @@ class GraphBuilder:
         return self
 
     def groups(self) -> dict[str, Group]:
-        """Collects the groups of all nodes and variables."""
-        node_group_dicts = [n.groups for n in self.nodes if n.groups]
-        var_group_dicts = [v.groups for v in self.vars if v.groups]
-        dictlist = node_group_dicts + var_group_dicts
-
-        return {name: grp for grpdict in dictlist for name, grp in grpdict.items()}
+        """Collects the groups from all nodes and variables."""
+        nodes, _vars = self._all_nodes_and_vars()
+        g1 = {g.name: g for n in nodes for g in n.groups.values()}
+        g2 = {g.name: g for v in _vars for g in v.groups.values()}
+        return g1 | g2
 
     def add_groups(self, *groups: Group) -> GraphBuilder:
         """Adds groups to the graph."""
 
-        unique_names = {group.name for group in groups}
-        if len(unique_names) != len(groups):
-            raise RuntimeError("Groups must have unique names.")
-
-        existing_groups = self.groups()
-
         for group in groups:
-            if group.name in existing_groups:
+            old = self.groups()
+
+            if group.name in old and group is not old[group.name]:
                 raise RuntimeError(
-                    f"There is already a group of name '{group.name}' in {self}."
+                    f"Group with name {repr(group.name)} already exists "
+                    "in graph builder"
                 )
+
             self.add(*group.nodes_and_vars.values())
+
         return self
 
     def build_model(self, copy: bool = False) -> Model:
@@ -675,8 +673,12 @@ class Model:
             nodes_and_vars = [*model.nodes.values(), *model.vars.values()]
             model.pop_nodes_and_vars()
 
+        groups = {g for nv in nodes_and_vars for g in nv.groups.values()}
         self._nodes = {nv.name: nv for nv in nodes_and_vars if isinstance(nv, Node)}
         self._vars = {nv.name: nv for nv in nodes_and_vars if isinstance(nv, Var)}
+
+        if len({g.name for g in groups}) < len(groups):
+            raise RuntimeError("Model received groups with duplicate names")
 
         if len(self._nodes) < sum(isinstance(nv, Node) for nv in nodes_and_vars):
             raise RuntimeError("Model received nodes with duplicate names")
@@ -776,12 +778,10 @@ class Model:
         self._auto_update = auto_update
 
     def groups(self) -> dict[str, Group]:
-        """Collects the groups in the model's nodes and variables."""
-        node_group_dicts = [n.groups for n in self._nodes.values() if n.groups]
-        var_group_dicts = [v.groups for v in self._vars.values() if v.groups]
-        dictlist = node_group_dicts + var_group_dicts
-
-        return {name: grp for grpdict in dictlist for name, grp in grpdict.items()}
+        """Collects the groups from all nodes and variables."""
+        g1 = {g.name: g for n in self._nodes.values() for g in n.groups.values()}
+        g2 = {g.name: g for v in self._vars.values() for g in v.groups.values()}
+        return g1 | g2
 
     def copy_nodes_and_vars(self) -> tuple[dict[str, Node], dict[str, Var]]:
         """Returns an unfrozen deep copy of the model nodes and variables."""

--- a/tests/model/test_graph_builder.py
+++ b/tests/model/test_graph_builder.py
@@ -310,3 +310,10 @@ def test_add_group_with_duplicate_name() -> None:
     g2 = lnodes.Group("g1", var1=v2)
     with pytest.raises(RuntimeError):
         lmodel.GraphBuilder().add_groups(g1, g2)
+
+
+def test_add_same_group_twice() -> None:
+    v1 = lnodes.Var(0.0, name="v1")
+    g1 = lnodes.Group("g1", var1=v1)
+    gb = lmodel.GraphBuilder().add_groups(g1, g1)
+    assert v1 in gb.vars

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -14,6 +14,7 @@ from liesel.model.nodes import (
     Calc,
     Data,
     Dist,
+    Group,
     Obs,
     Param,
     TransientNode,
@@ -290,6 +291,28 @@ class TestModel:
         assert len(nodes) == n_nodes - 3
         assert not model.vars
         assert not model.nodes
+
+    def test_unique_groups(self) -> None:
+        v1 = Var(0.0, name="v1")
+        v2 = Var(0.0, name="v2")
+        g1 = Group("g1", var1=v1, var2=v2)
+        m = Model([v1, v2])
+
+        assert g1 in m.groups().values()
+
+        m.pop_nodes_and_vars()
+        g2 = Group("g2", var1=v1, var2=v2)
+        m = Model([v1, v2])
+
+        assert g1 in m.groups().values()
+        assert g2 in m.groups().values()
+
+        m.pop_nodes_and_vars()
+        v3 = Var(0.0, name="v3")
+        Group("g1", var3=v3)
+
+        with pytest.raises(RuntimeError):
+            Model([v1, v2, v3])
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
With these improved uniqueness checks, (1) it is now possible to add the same group twice to a graph builder, and (2) the group names are now checked for uniqueness when added directly to a model without a graph builder.

Do you see any problems, @jobrachem? :eyes: