### PR TITLE
Add Group docstring

### DIFF
--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -30,6 +30,7 @@ __all__ = [
     "Data",
     "Dist",
     "Distribution",
+    "Group",
     "InputGroup",
     "Node",
     "NodeState",
@@ -963,6 +964,67 @@ def add_group(name: str, **kwargs: Node | Var) -> Group:
 
 
 class Group:
+    """
+    A group holds a collection of related :class:`.Var` and/or :class:`.Node` objects.
+
+    They allow you to do three basic things:
+
+    1. Store related notes together for easier access.
+    2. Access their member nodes and vars via ``group["name"]``, where ``"name"`` is the
+       group-specific name, which can be different from the :attr:`.Var.name` /
+       :attr:`.Node.name`.
+    3. Easily retrieve a variable's or a node's value from a :attr:`.Model.state` based
+       on their group-specific name via :meth:`.value_from`.
+
+    Parameters
+    ----------
+    name
+        The group's name. Must be unique among the groups of its memebers, and within a
+        model.
+    **nodes_and_vars
+        An arbitrary number of nodes or variables. The keywords will be used as the
+        group-specific names of the respective objects.
+
+    See Also
+    --------
+
+    * :attr:`.Node.groups` and :attr:`.Var.groups` are :obj:`MappingProxyType` objects
+      (basically read-only dictionaries) of the groups whose member the respective
+      object is.
+    * :meth:`.GraphBuilder.groups` and :meth:`.Model.groups` are methods that collect
+      and return all groups within the graph/model.
+
+    Notes
+    -----
+    Note the following:
+
+    - Groups can only be filled upon initialisation.
+    - After initialisation, variables and nodes cannot be removed from a group.
+
+
+    Examples
+    --------
+
+    Add a variable to a group:
+
+    >>> my_var = lsl.Var(0., name="long_unique_variable_name")
+    >>> grp = lsl.Group(name="demo_group", short_name=my_var)
+    >>> grp
+    Group<demo_group>
+
+    Access the variable by its group-specific name:
+
+    >>> grp["short_name"]
+    Var<long_unique_variable_name>
+
+    Retrieve the value of a variable from a model state:
+
+    >>> model_state = {my_var.value_node.name: lsl.NodeState(10., False)}
+    >>> grp.value_from(model_state, "short_name")
+    10.0
+
+    """
+
     def __init__(self, name: str, **nodes_and_vars: Node | Var) -> None:
         self._name = name
         self._nodes_and_vars = nodes_and_vars


### PR DESCRIPTION
This adds a docstring to the group object and adds it to the `__all__` attribute in `liesel.model.nodes`.