### PR TITLE
Sample from mvn degenerate distribution

### DIFF
--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -72,13 +72,13 @@ class MultivariateNormalDegenerate(tfd.Distribution):
     log_pdet
         The log-pseudo-determinant of the precision matrix. Optional.
     validate_args
-        Python ``bool``, default ``False``. When ``True``, distribution parameters \\
-        are checked for validity despite possibly degrading runtime performance. \\ When
-        ``False``, invalid inputs may silently render incorrect outputs.
+        Python ``bool``, default ``False``. When ``True``, distribution parameters \
+        are checked for validity despite possibly degrading runtime performance. \
+        When ``False``, invalid inputs may silently render incorrect outputs.
     allow_nan_stats
         Python ``bool``, default ``True``. When ``True``, statistics (e.g., mean, \
         mode, variance) use the value ``NaN`` to indicate the result is undefined. \
-        When ``False``, an exception is raised if one or more of the statistic's \\
+        When ``False``, an exception is raised if one or more of the statistic's \
         batch members are undefined.
     name
         Python ``str``, name prefixed to ``Ops`` created by this class.
@@ -88,9 +88,10 @@ class MultivariateNormalDegenerate(tfd.Distribution):
     * If they are not provided as arguments, ``rank`` and ``log_pdet`` are computed
       based on the eigenvalues of the precision matrix ``prec``. This is an expensive
       operation and can be avoided by specifying the corresponding arguments.
-    * When you draw samples from the distribution via `:meth:.sample`, an
-      eigendecomposition of the distribution's precision matrices is always computed
-      once, because sampling requires both the eigenvalues and eigenvectors.
+    * When you draw samples from the distribution via :meth:`.sample`, it is always
+      necessary to compute the eigendecomposition of the distribution's precision
+      matrices once and cache it, because sampling requires both the eigenvalues
+      and eigenvectors.
     """
 
     def __init__(

--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -143,7 +143,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
 
     @cached_property
     def eig(self) -> tuple[Array, Array]:
-        """Eigenvalues and eigenvectors of the precision matrices."""
+        """Eigenvalues and eigenvectors of the distribution's precision matrices."""
         return jnp.linalg.eigh(self._prec)
 
     @cached_property
@@ -166,7 +166,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
 
     @cached_property
     def rank(self) -> Array | float:
-        """Ranks of the precision matrices."""
+        """Ranks of the distribution's precision matrices."""
         if self._rank is not None:
             return self._rank
         evals, _ = self.eig
@@ -174,7 +174,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
 
     @cached_property
     def log_pdet(self) -> Array | float:
-        """Log pseudo-determinant of the precision matrices."""
+        """Log pseudo-determinant of the distribution's precision matrices."""
         if self._log_pdet is not None:
             return self._log_pdet
         evals, _ = self.eig

--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -178,11 +178,15 @@ class MultivariateNormalDegenerate(tfd.Distribution):
 
     @cached_property
     def eig(self) -> tuple[Array, Array]:
-        """Eigenvalues and eigenvectors of the precision."""
-        return jax.scipy.linalg.eigh(self._prec)
+        """Eigenvalues and eigenvectors of the precision matrices."""
+        return jnp.linalg.eigh(self._prec)
 
     @cached_property
     def _sample_transformer(self) -> Array:
+        """
+        Let ``prec = Q @ A @ Q.T`` be the eigendecomposition of the precision matrix.
+        In essence, this property returns ``Q @ jnp.sqrt(1/A)``.
+        """
         eigenvalues, evecs = self.eig
 
         numerically_zero = eigenvalues < 1e-6
@@ -197,6 +201,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
 
     @cached_property
     def rank(self) -> Array | float:
+        """Ranks of the precision matrices."""
         if self._rank is not None:
             return self._rank
         evals, _ = self.eig
@@ -204,7 +209,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
 
     @cached_property
     def log_pdet(self) -> Array | float:
-        """Log pseudo-determinant."""
+        """Log pseudo-determinant of the precision matrices."""
         if self._log_pdet is not None:
             return self._log_pdet
         evals, _ = self.eig

--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -131,8 +131,8 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         self._broadcast_batch_shape = jnp.broadcast_shapes(prec_batches, loc_batches)
         nbatch = len(self.batch_shape)
 
-        self._prec = jnp.expand_dims(prec, jnp.arange(nbatch - len(prec_batches)))
-        self._loc = jnp.expand_dims(loc, jnp.arange(nbatch - len(loc_batches)))
+        self._prec = jnp.expand_dims(prec, tuple(range(nbatch - len(prec_batches))))
+        self._loc = jnp.expand_dims(loc, tuple(range(nbatch - len(loc_batches))))
 
         super().__init__(
             dtype=prec.dtype,
@@ -239,7 +239,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         event_shape = sqrt_eval.shape[-1]
         shape = sqrt_eval.shape + (event_shape,)
 
-        r = jnp.arange(event_shape)
+        r = tuple(range(event_shape))
         diags = jnp.zeros(shape).at[..., r, r].set(sqrt_eval)
         return evecs @ diags
 

--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -234,7 +234,6 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         """
         eigenvalues, evecs = self.eig
 
-        # numerically_zero = eigenvalues < 1e-6
         sqrt_eval = jnp.sqrt(1 / eigenvalues)
         sqrt_eval = jnp.where(eigenvalues < 1e-6, 0.0, sqrt_eval)
 
@@ -265,7 +264,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         shape = [n] + self.batch_shape + self.event_shape
 
         # The added dimension at the end here makes sure that matrix multiplication
-        # with the "transformer" matrices works out correctly.
+        # with the "projector" matrices works out correctly.
         z = jax.random.normal(key=seed, shape=shape + [1])
 
         # Add a dimension at 0 for the sample size.

--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -84,7 +84,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         Python ``str``, name prefixed to ``Ops`` created by this class.
     tol
         Numerical tolerance for determining which eigenvalues of the distribution's \
-        precision matrices should be treated as zero. Used in :attr:`.rank` and \
+        precision matrices should be treated as zeros. Used in :attr:`.rank` and \
         :attr:`.log_pdet`, if they are computed by the class. Also used in \
         :meth:`.sample`.
 
@@ -236,7 +236,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
     @cached_property
     def _sqrt_pcov(self) -> Array:
         """
-        Square-roots of the distribution's pseudo-covariance matrices.
+        Square roots of the distribution's pseudo-covariance matrices.
 
         Let ``prec = Q @ A @ Q.T`` be the eigendecomposition of the precision matrix.
         In essence, this property returns ``Q @ jnp.sqrt(1/A)``.
@@ -263,7 +263,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
 
     @cached_property
     def log_pdet(self) -> Array | float:
-        """Log pseudo-determinant of the distribution's precision matrices."""
+        """Log-pseudo-determinants of the distribution's precision matrices."""
         if self._log_pdet is not None:
             return self._log_pdet
         evals, _ = self.eig
@@ -273,7 +273,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         shape = [n] + self.batch_shape + self.event_shape
 
         # The added dimension at the end here makes sure that matrix multiplication
-        # with the "projector" matrices works out correctly.
+        # with the "sqrt pcov" matrices works out correctly.
         z = jax.random.normal(key=seed, shape=shape + [1])
 
         # Add a dimension at 0 for the sample size.

--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -234,8 +234,10 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         return jnp.linalg.eigh(self._prec)
 
     @cached_property
-    def _projector(self) -> Array:
+    def _sqrt_pcov(self) -> Array:
         """
+        Square-roots of the distribution's pseudo-covariance matrices.
+
         Let ``prec = Q @ A @ Q.T`` be the eigendecomposition of the precision matrix.
         In essence, this property returns ``Q @ jnp.sqrt(1/A)``.
         """
@@ -275,8 +277,8 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         z = jax.random.normal(key=seed, shape=shape + [1])
 
         # Add a dimension at 0 for the sample size.
-        projector = jnp.expand_dims(self._projector, 0)
-        centered_samples = jnp.reshape(projector @ z, shape)
+        sqrt_pcov = jnp.expand_dims(self._sqrt_pcov, 0)
+        centered_samples = jnp.reshape(sqrt_pcov @ z, shape)
 
         # Add a dimension at 0 for the sample size.
         loc = jnp.expand_dims(self._loc, 0)

--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -72,23 +72,25 @@ class MultivariateNormalDegenerate(tfd.Distribution):
     log_pdet
         The log-pseudo-determinant of the precision matrix. Optional.
     validate_args
-        Python ``bool``, default ``False``. When ``True``, distribution parameters \
-        are checked for validity despite possibly degrading runtime performance. \
-        When ``False``, invalid inputs may silently render incorrect outputs.
+        Python ``bool``, default ``False``. When ``True``, distribution parameters \\
+        are checked for validity despite possibly degrading runtime performance. \\ When
+        ``False``, invalid inputs may silently render incorrect outputs.
     allow_nan_stats
         Python ``bool``, default ``True``. When ``True``, statistics (e.g., mean, \
         mode, variance) use the value ``NaN`` to indicate the result is undefined. \
-        When ``False``, an exception is raised if one or more of the statistic's \
+        When ``False``, an exception is raised if one or more of the statistic's \\
         batch members are undefined.
     name
         Python ``str``, name prefixed to ``Ops`` created by this class.
 
     Notes
     -----
-    If they are not provided as arguments, the constructor computes ``rank`` and
-    ``log_pdet`` based on the eigenvalues of the precision matrix ``prec``. This
-    is an expensive operation and can be avoided by specifying the corresponding
-    arguments.
+    * If they are not provided as arguments, ``rank`` and ``log_pdet`` are computed
+      based on the eigenvalues of the precision matrix ``prec``. This is an expensive
+      operation and can be avoided by specifying the corresponding arguments.
+    * When you draw samples from the distribution via `:meth:.sample`, an
+      eigendecomposition of the distribution's precision matrices is always computed
+      once, because sampling requires both the eigenvalues and eigenvectors.
     """
 
     def __init__(

--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -233,8 +233,9 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         """
         eigenvalues, evecs = self.eig
 
-        numerically_zero = eigenvalues < 1e-6
-        sqrt_eval = jnp.sqrt(1 / eigenvalues).at[numerically_zero].set(0)
+        # numerically_zero = eigenvalues < 1e-6
+        sqrt_eval = jnp.sqrt(1 / eigenvalues)
+        sqrt_eval = jnp.where(eigenvalues < 1e-6, 0.0, sqrt_eval)
 
         event_shape = sqrt_eval.shape[-1]
         shape = sqrt_eval.shape + (event_shape,)

--- a/liesel/distributions/mvn_degen.py
+++ b/liesel/distributions/mvn_degen.py
@@ -182,7 +182,7 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         return jnp.linalg.eigh(self._prec)
 
     @cached_property
-    def _sample_transformer(self) -> Array:
+    def _projector(self) -> Array:
         """
         Let ``prec = Q @ A @ Q.T`` be the eigendecomposition of the precision matrix.
         In essence, this property returns ``Q @ jnp.sqrt(1/A)``.
@@ -300,8 +300,8 @@ class MultivariateNormalDegenerate(tfd.Distribution):
         z = jax.random.normal(key=seed, shape=shape + [1])
 
         # Add a dimension at 0 for the sample size.
-        transformer = jnp.expand_dims(self._sample_transformer, 0)
-        centered_samples = jnp.reshape(transformer @ z, shape)
+        projector = jnp.expand_dims(self._projector, 0)
+        centered_samples = jnp.reshape(projector @ z, shape)
 
         # Add a dimension at 0 for the sample size.
         loc = jnp.expand_dims(self._loc, 0)

--- a/tests/distributions/test_mvn_degen.py
+++ b/tests/distributions/test_mvn_degen.py
@@ -115,7 +115,7 @@ def mvn_batch():
 
 
 class TestComputePseudoLogDet:
-    def test_rank_and_log_pdet(self):
+    def test_rank_and_log_pdet(self) -> None:
         """
         Test that pseudo-log-determinant computation works with and without given rank.
         """
@@ -136,7 +136,7 @@ class TestComputePseudoLogDet:
         assert ldet2a[1] == pytest.approx(ldet2b[1])
         assert ldet3a[1] == pytest.approx(ldet3b[1])
 
-    def test_jit_rank_and_log_pdet(self):
+    def test_jit_rank_and_log_pdet(self) -> None:
         """Test that pseudo-log-determinant computation can be jitted."""
         K = jnp.eye(5)
         prec = K / 2.0
@@ -151,7 +151,7 @@ class TestComputePseudoLogDet:
         assert ldet1[1] == pytest.approx(ldet3[1])
         assert ldet1[1] == pytest.approx(ldet4[1])
 
-    def test_rank_and_log_pdet_batch_full_computation(self):
+    def test_rank_and_log_pdet_batch_full_computation(self) -> None:
         """Test that pseudo-log-determinant computation works for batches."""
         K1 = jnp.diag(jnp.array([2.0, 0.0, 0.0]))
         K2 = jnp.diag(jnp.array([2.0, 3.0, 0.0]))
@@ -163,12 +163,12 @@ class TestComputePseudoLogDet:
 
         ldet = _rank_and_log_pdet(K_batch)
 
-        assert ldet1[0] == pytest.approx(ldet[0][0])
-        assert ldet1[1] == pytest.approx(ldet[1][0])
-        assert ldet2[0] == pytest.approx(ldet[0][1])
-        assert ldet2[1] == pytest.approx(ldet[1][1])
+        assert ldet1[0] == pytest.approx(ldet[0][0])  # type: ignore
+        assert ldet1[1] == pytest.approx(ldet[1][0])  # type: ignore
+        assert ldet2[0] == pytest.approx(ldet[0][1])  # type: ignore
+        assert ldet2[1] == pytest.approx(ldet[1][1])  # type: ignore
 
-    def test_rank_and_log_pdet_batch_given_rank(self):
+    def test_rank_and_log_pdet_batch_given_rank(self) -> None:
         """
         Test that pseudo-log-determinant computation with given ranks works for simple
         batches.
@@ -188,7 +188,7 @@ class TestComputePseudoLogDet:
         assert ldet2[0] == pytest.approx(ldet[0][1])
         assert ldet2[1] == pytest.approx(ldet[1][1])
 
-    def test_rank_and_log_pdet_big_batch_given_rank(self):
+    def test_rank_and_log_pdet_big_batch_given_rank(self) -> None:
         """
         Test that pseudo-log-determinant computation with given ranks works for nested
         batches.
@@ -209,10 +209,10 @@ class TestComputePseudoLogDet:
             K_batch, rank=jnp.array([[ldet1[0], ldet2[0]], [ldet3[0], ldet4[0]]])
         )
 
-        assert ldet1[0] == pytest.approx(ldet[0][0, 0])
-        assert ldet1[1] == pytest.approx(ldet[1][0, 0])
-        assert ldet2[0] == pytest.approx(ldet[0][0, 1])
-        assert ldet2[1] == pytest.approx(ldet[1][0, 1])
+        assert ldet1[0] == pytest.approx(ldet[0][0, 0])  # type: ignore
+        assert ldet1[1] == pytest.approx(ldet[1][0, 0])  # type: ignore
+        assert ldet2[0] == pytest.approx(ldet[0][0, 1])  # type: ignore
+        assert ldet2[1] == pytest.approx(ldet[1][0, 1])  # type: ignore
 
 
 class TestMVNDegenerateValues:
@@ -221,7 +221,7 @@ class TestMVNDegenerateValues:
     correctly.
     """
 
-    def test_log_prob_from_penalty(self, beta, K, tau2, log_prob_baseline):
+    def test_log_prob_from_penalty(self, beta, K, tau2, log_prob_baseline) -> None:
         """
         Log prob obtained from MultivariateNormalDegenerate constructed from penalty
         matrix should be equal to the baseline log prob.
@@ -235,7 +235,7 @@ class TestMVNDegenerateValues:
 
         assert log_prob == pytest.approx(log_prob_baseline)
 
-    def test_log_prob_from_init(self, beta, K, tau2, log_prob_baseline):
+    def test_log_prob_from_init(self, beta, K, tau2, log_prob_baseline) -> None:
         """
         Log prob obtained from MultivariateNormalDegenerate constructed directly from
         the init should be equal to the baseline log prob.
@@ -256,25 +256,25 @@ class TestMVNDegenerateValues:
 
 
 class TestMVNDegenerateBatches:
-    def test_shape_single_sample(self, beta, K, tau2):
+    def test_shape_single_sample(self, beta, K, tau2) -> None:
         """Log prob should be a scalar."""
         mvn = MultivariateNormalDegenerate(loc=0.0, prec=K / tau2)
         log_prob = mvn.log_prob(beta)
         assert jnp.ndim(log_prob) == 0
 
-    def test_shape_two_samples(self, beta, K, tau2):
+    def test_shape_two_samples(self, beta, K, tau2) -> None:
         """Log prob should have shape (2,)."""
         mvn = MultivariateNormalDegenerate(loc=0.0, prec=K / tau2)
         log_prob = mvn.log_prob([beta, beta])
         assert log_prob.shape == (2,)
 
-    def test_shape_nested_samples(self, beta, K, tau2):
+    def test_shape_nested_samples(self, beta, K, tau2) -> None:
         """Log prob should have shape (2, 2)."""
         mvn = MultivariateNormalDegenerate(loc=0.0, prec=K / tau2)
         log_prob = mvn.log_prob([[beta, beta], [beta, beta]])
         assert log_prob.shape == (2, 2)
 
-    def test_shape_unequal_sample_shapes(self, beta, K, tau2):
+    def test_shape_unequal_sample_shapes(self, beta, K, tau2) -> None:
         """Input samples must be of the same size."""
         mvn = MultivariateNormalDegenerate(loc=0.0, prec=K / tau2)
         with pytest.raises(ValueError):
@@ -283,7 +283,7 @@ class TestMVNDegenerateBatches:
         with pytest.raises(ValueError):
             mvn.log_prob([[beta, beta], beta])
 
-    def test_from_penalty_batch(self, beta, K, tau2):
+    def test_from_penalty_batch(self, beta, K, tau2) -> None:
         """The from_penalty constructor should be able to deal with batches."""
         rank, log_det = determinant_structure_degen(K)
         rank2, log_det2 = determinant_structure_degen(jnp.eye(5))
@@ -297,7 +297,7 @@ class TestMVNDegenerateBatches:
 
         assert mvn.log_prob(beta).shape == (2,)
 
-    def test_batch_precision(self, beta, K):
+    def test_batch_precision(self, beta, K) -> None:
         """
         Tests the distribution with two precision matrices while the location remains
         constant.
@@ -329,7 +329,7 @@ class TestMVNDegenerateBatches:
         lp2 = mvn2.log_prob(beta)
         assert lp[1] == lp2
 
-    def test_batch_precision_2_beta_samples(self, beta, K):
+    def test_batch_precision_2_beta_samples(self, beta, K) -> None:
         """
         Tests the distribution with two precision matrices while the location remains
         constant.
@@ -352,7 +352,7 @@ class TestMVNDegenerateBatches:
         assert lp.shape == (2,)
         assert jnp.allclose(lp, mvn.log_prob(beta))
 
-    def test_batch_loc(self, beta, K):
+    def test_batch_loc(self, beta, K) -> None:
         """
         Tests the distribution with two location values while the precision matrix
         remains constant.
@@ -381,7 +381,7 @@ class TestMVNDegenerateBatches:
         lp2 = mvn2.log_prob(beta)
         assert lp[1] == lp2
 
-    def test_batch_loc_prec(self, beta, K):
+    def test_batch_loc_prec(self, beta, K) -> None:
         """
         Tests the distribution with two location values and two precision matrices.
 
@@ -416,7 +416,7 @@ class TestMVNDegenerateBatches:
         lp2 = mvn2.log_prob(beta)
         assert lp[1] == lp2
 
-    def test_batch_2loc_3prec(self, beta, mvn_batch):
+    def test_batch_2loc_3prec(self, beta, mvn_batch) -> None:
         """
         Tests the distribution with three precision matrices and two locations.
 
@@ -461,7 +461,7 @@ class TestMVNDegenerateBatches:
         assert lp[1, 1] == pytest.approx(lp5)
         assert lp[1, 2] == pytest.approx(lp6)
 
-    def test_batch_2loc_3prec_multiple_samples(self, beta, mvn_batch):
+    def test_batch_2loc_3prec_multiple_samples(self, beta, mvn_batch) -> None:
         """
         Sample shape has to be (1,) or be broadcastable with batch shape.
 
@@ -486,7 +486,7 @@ class TestMVNDegenerateBatches:
         lp = mvn.log_prob(samples_reshaped)
         assert lp.shape == (4, 2, 3)
 
-    def test_batch_2loc_3prec_multiple_samples_loc(self, beta, mvn_batch):
+    def test_batch_2loc_3prec_multiple_samples_loc(self, beta, mvn_batch) -> None:
         """
         Tests a distribution with batch size (2, 3) and multiple samples.
 
@@ -521,7 +521,7 @@ class TestMVNDegenerateBatches:
         assert jnp.allclose(lp2[0], lp1)
         assert jnp.allclose(lp2[1], lp1)
 
-    def test_batch_2loc_3prec_multiple_samples_prec(self, beta, mvn_batch):
+    def test_batch_2loc_3prec_multiple_samples_prec(self, beta, mvn_batch) -> None:
         """
         Tests a distribution with batch size (2, 3) and multiple samples.
 
@@ -560,7 +560,7 @@ class TestMVNDegenerateBatches:
         assert jnp.allclose(lp4[0], lp3)
         assert jnp.allclose(lp4[1], lp3)
 
-    def test_batch_2by2_loc_3_prec(self, beta, K):
+    def test_batch_2by2_loc_3_prec(self, beta, K) -> None:
         """
         Tests the distribution with 2x2 locations and three precision matrices.
 
@@ -587,7 +587,7 @@ class TestMVNDegenerateBatches:
         # assert correct output shape
         assert lp.shape == (2, 2, 3)
 
-    def test_batch_of_smoothing_parameters(self, beta, K):
+    def test_batch_of_smoothing_parameters(self, beta, K) -> None:
         """Tests that batches of smoothing parameters can be handled."""
         var = jnp.array([1.0, 2.0, 3.0])
         mvnd1 = MultivariateNormalDegenerate.from_penalty(0.0, var=var, pen=K)
@@ -604,7 +604,7 @@ class TestMVNDegenerateAgainstTensorFlow:
     probability.
     """
 
-    def test_scalar_location(self, beta):
+    def test_scalar_location(self, beta) -> None:
         """When location is a scalar."""
         vcov = jnp.eye(5)
         mvn = tfd.MultivariateNormalFullCovariance(loc=0.0, covariance_matrix=vcov)
@@ -616,7 +616,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         assert mvn.log_prob(beta).shape == mvnd.log_prob(beta).shape
         assert jnp.allclose(mvn.log_prob(beta), mvnd.log_prob(beta))
 
-    def test_1darray_location(self, beta):
+    def test_1darray_location(self, beta) -> None:
         """When location is a 1d array."""
         vcov = jnp.eye(5)
         mvn = tfd.MultivariateNormalFullCovariance(
@@ -630,7 +630,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         assert mvn.log_prob(beta).shape == mvnd.log_prob(beta).shape
         assert jnp.allclose(mvn.log_prob(beta), mvnd.log_prob(beta))
 
-    def test_2darray_location_1batch(self, beta):
+    def test_2darray_location_1batch(self, beta) -> None:
         """
         When location is a 2d array, defining one batch.
 
@@ -649,7 +649,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         assert mvn.log_prob(sample).shape == mvnd.log_prob(sample).shape
         assert jnp.allclose(mvn.log_prob(sample), mvnd.log_prob(sample))
 
-    def test_2darray_location_2batches(self, beta):
+    def test_2darray_location_2batches(self, beta) -> None:
         """
         When location is a 2d array, defining two batches.
 
@@ -668,7 +668,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         assert mvn.log_prob(sample).shape == mvnd.log_prob(sample).shape
         assert jnp.allclose(mvn.log_prob(sample), mvnd.log_prob(sample))
 
-    def test_x(self, beta):
+    def test_x(self, beta) -> None:
         """
         When location is a 1d array, it must have the dimension of the event size.
         """
@@ -681,7 +681,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         with pytest.raises(ValueError):
             MultivariateNormalDegenerate(loc=loc, prec=vcov)
 
-    def test_3darray_location(self, beta):
+    def test_3darray_location(self, beta) -> None:
         """
         When location is a 3d array.
 
@@ -700,7 +700,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         assert mvn.log_prob(sample).shape == mvnd.log_prob(sample).shape
         assert jnp.allclose(mvn.log_prob(sample), mvnd.log_prob(sample))
 
-    def test_3darray_location_multiple_samples(self, beta):
+    def test_3darray_location_multiple_samples(self, beta) -> None:
         """
         When location is a 3d array.
 
@@ -722,7 +722,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         assert mvn.log_prob(sample).shape == mvnd.log_prob(sample).shape
         assert jnp.allclose(mvn.log_prob(sample), mvnd.log_prob(sample))
 
-    def test_multiple_precisions(self, beta):
+    def test_multiple_precisions(self, beta) -> None:
         """
         When two precision matrices are used.
 
@@ -742,7 +742,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         assert mvn.log_prob(sample).shape == mvnd.log_prob(sample).shape
         assert jnp.allclose(mvn.log_prob(sample), mvnd.log_prob(sample))
 
-    def test_multiple_precisions_nested(self, beta):
+    def test_multiple_precisions_nested(self, beta) -> None:
         """
         When two x two precision matrices are used.
 
@@ -762,7 +762,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         assert mvn.log_prob(sample).shape == mvnd.log_prob(sample).shape
         assert jnp.allclose(mvn.log_prob(sample), mvnd.log_prob(sample))
 
-    def test_incompatible_shapes(self):
+    def test_incompatible_shapes(self) -> None:
         """
         The :class:`.MultivariateNormalDegenerate` should behave similar to the
         TensorFlow probability distribution when initialized with parameter arrays that
@@ -781,7 +781,7 @@ class TestMVNDegenerateAgainstTensorFlow:
         with pytest.raises(ValueError):
             MultivariateNormalDegenerate(loc=loc, prec=vcov)
 
-    def test_multiple_samples(self, beta):
+    def test_multiple_samples(self, beta) -> None:
         """
         Tests that :class:`.MultivariateNormalDegenerate` handles multiple samples in
         the same way as the TFD baseline class ``MultivariateNormalFullCovariance``.


### PR DESCRIPTION
Closes #34.

The main function is `MultivariateNormalDegenerate._sample_n`, which allows us to sample like this:

```python
import jax.random as jrd
import jax.numpy as jnp
import liesel.model as lsl

key = jrd.PRNGKey(42)
D = jnp.diff(jnp.eye(5))

mvnd = lsl.MultivariateNormalDegenerate.from_penalty(loc=0.0, var=1.0, pen=D.T @ D)
mvnd.sample(seed=key)
```

Some notes:

1. I took the opportunity to also refactor the module a bit. I separated the helper function `_rank_and_log_pdet` into `_rank` and `_log_pdet`. Those new functions now take an array of eigenvalues instead of the precision matrix as input. 
2. The original function `_rank_and_log_pdet` had some special behavior to ensure efficiency, i.e., if you supplied both a `rank` and a `log_pdet` argument, the function essentially did nothing and just returned its inputs. I moved this functionality to the new `MultivariateNormalDegenerate.rank` and `MultivariateNormalDegenerate.log_pdet` properties. They are public, because - why not? 
3. I implemented them using the [`@cached_property`](https://docs.python.org/3/library/functools.html#functools.cached_property) decorator. This decorator computes its value once and then saves it as an attribute on the instance. Consecutive calls are then reduced to lookups.
4. I used this decorator again to provide the $QA^{1/2}$ projector matrix (see #34) in the `_sample_n` function. I think this is a nice way to both keep the code clean and relatively easy to read, while making sure that we do not have unnecessary repeated computations. 
5. I'm not entirely sure about the name for the $QA^{1/2}$ property. For the time being, I simply called it `_projector`. If you have a better idea, I'm happy!

Looking forward to your review @hriebl! 