### PR TITLE
Add doctest action

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -1,0 +1,27 @@
+name: doctest
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install liesel
+        run: |
+          pip install .[dev]
+          pip list
+
+      - name: Run pytest
+        run: pytest --doctest-modules liesel

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install liesel
         run: |
-          pip install .[dev]
+          pip install .[dev,pymc]
           pip list
 
       - name: Run pytest

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -1,13 +1,13 @@
 name: doctest
 
 on:
-  pull_request:
-    branches: [main]
   push:
+    branches: [main]
+  pull_request:
     branches: [main]
 
 jobs:
-  pytest:
+  doctest:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -1,6 +1,8 @@
 name: doctest
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
 

--- a/conftest.py
+++ b/conftest.py
@@ -102,7 +102,7 @@ def local_caplog():
 
 
 @pytest.fixture(autouse=True)
-def add_np(doctest_namespace):
+def add_doctest_imports(doctest_namespace):
     doctest_namespace["np"] = np
     doctest_namespace["jax"] = jax
     doctest_namespace["jnp"] = jnp

--- a/conftest.py
+++ b/conftest.py
@@ -2,8 +2,14 @@ import logging
 from collections.abc import Generator
 from contextlib import contextmanager
 
+import jax
+import jax.numpy as jnp
+import numpy as np
 import pytest
 from _pytest.logging import LogCaptureHandler
+
+import liesel.goose as gs
+import liesel.model as lsl
 
 
 def pytest_addoption(parser):
@@ -93,3 +99,12 @@ def local_caplog():
     """
 
     yield local_caplog_fn
+
+
+@pytest.fixture(autouse=True)
+def add_np(doctest_namespace):
+    doctest_namespace["np"] = np
+    doctest_namespace["jax"] = jax
+    doctest_namespace["jnp"] = jnp
+    doctest_namespace["gs"] = gs
+    doctest_namespace["lsl"] = lsl

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,6 @@ extensions = [
     # "sphinx.ext.linkcode",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",
-    "sphinx.ext.doctest",
     "sphinx_remove_toctrees",  # speed up builds with many stub pages
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
@@ -71,15 +70,6 @@ napoleon_use_rtype = False
 
 # sphinx_autodoc_typehints options
 typehints_defaults = "braces-after"
-
-# doctest setup
-doctest_global_setup = """
-import jax
-import jax.numpy as jnp
-import numpy as np
-import liesel.goose as gs
-import liesel.model as lsl
-"""
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
Adds a doctest action to our GitHub CI.

I could also imagine that this can simply be executed as an additional step in the existing `pytest-pull.yml` action. However, if it is its own action, we have a clearly defined distinction between failing doctests and failing unit tests, which I think is nice.