### PR TITLE
Refactor distregbuilder

### DIFF
--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -275,6 +275,14 @@ class Node(ABC):
 
         return self
 
+    @no_model_method
+    def add_inputs(self, *inputs: Any, **kwinputs: Any) -> Node:
+        """Adds non-keyword and keyword input nodes to the existing ones."""
+        inputs = self.inputs + inputs
+        kwinputs = self.kwinputs | kwinputs
+        self.set_inputs(*inputs, **kwinputs)
+        return self
+
     @property
     def state(self) -> NodeState:
         """

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -185,6 +185,14 @@ class Node(ABC):
         self._var = None
         return self
 
+    @no_model_method
+    def add_inputs(self, *inputs: Any, **kwinputs: Any) -> Node:
+        """Adds non-keyword and keyword input nodes to the existing ones."""
+        inputs = self.inputs + inputs
+        kwinputs = self.kwinputs | kwinputs
+        self.set_inputs(*inputs, **kwinputs)
+        return self
+
     def all_input_nodes(self) -> tuple[Node, ...]:
         """Returns all non-keyword and keyword input nodes as a unique tuple."""
         return _unique_tuple(self.inputs, self.kwinputs.values())
@@ -273,14 +281,6 @@ class Node(ABC):
         kwinputs = {kw: self._to_node(_input) for kw, _input in kwinputs.items()}
         self._kwinputs.update(kwinputs)
 
-        return self
-
-    @no_model_method
-    def add_inputs(self, *inputs: Any, **kwinputs: Any) -> Node:
-        """Adds non-keyword and keyword input nodes to the existing ones."""
-        inputs = self.inputs + inputs
-        kwinputs = self.kwinputs | kwinputs
-        self.set_inputs(*inputs, **kwinputs)
         return self
 
     @property


### PR DESCRIPTION
This PR includes only the mildest changes that I have in mind. For the other ones, I think it is more productive to open a separate PR and discuss those changes separately.

### Specifically, the changes are:

1. The mandatory order in which methods have to be called is reversed now (add_response -> add_predictor -> add_smooth). Closes https://github.com/liesel-devs/liesel-internal/issues/212
2. All model-building methods of the distregbuilder now return `self`, such that method-chaining is completely allowed. Closes https://github.com/liesel-devs/liesel-internal/issues/142


In [#212](https://github.com/liesel-devs/liesel-internal/issues/212), we talked about exchanging `add_prediction` for a mandatory argument in `add_response`. When working on the builder though, I felt like this would make usage more clunky than before, because we also have to account for the `inverse_link` of the predictor.

Now, an example for usage of the DistRegBuilder would be:

```python
drb = (
    dr.DistRegBuilder()
    .add_response(y, tfd.Normal)

    .add_predictor("loc", tfb.Identity)
    .add_predictor("scale", tfb.Exp)

    .add_p_smooth(X, m=0.0, s=0.0, predictor="loc", name="xloc")
    .add_p_smooth(X, m=0.0, s=0.0, predictor="scale", name="xscale")
)
```