### PR TITLE
Pin pydata-sphinx-theme version to fix docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,7 +93,6 @@ html_logo = "../../misc/logo/logo-light.png"
 html_theme_options = {
     "repository_url": "https://github.com/liesel-devs/liesel",
     "use_repository_button": True,
-    "logo_only": True,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ dev =
     pyupgrade
     sphinx>=4.5
     sphinx-autodoc-typehints>=1.19
+    pydata-sphinx-theme<=0.13.1
     sphinx-book-theme>=0.3
     sphinx-copybutton>=0.5
     sphinx-remove-toctrees>=0.0.3


### PR DESCRIPTION
Apparently, the latest `pydata-sphinx-theme` [release](https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.13.2) broke our usage of `sphinx-book-theme`.

This PR is a hotfix for this issue, it pins down the version. In the near future, a permanent fix will be merged in pydata-sphinx-theme: 

- https://github.com/pydata/pydata-sphinx-theme/issues/1274
- https://github.com/executablebooks/sphinx-book-theme/issues/711