### PR TITLE
Implement use of monitor flag for liesel.models

### DIFF
--- a/liesel/model/goose.py
+++ b/liesel/model/goose.py
@@ -99,6 +99,12 @@ class GooseModel:
         """
         return model_state["_model_log_prob"].value
 
+    def monitored_keys(self) -> Iterable[str]:
+        """
+        Returns a list of node names that should be monitored during sampling.
+        """
+        return [name for name, node in self._model.nodes.items() if node.monitor]
+
 
 def finite_discrete_gibbs_kernel(
     name: str, model: Model, outcomes: Sequence | None = None

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -56,7 +56,7 @@ def _reduced_sum(*args: Array) -> Array:
     return sum(reduced)
 
 
-def _transform_back(var_transformed: Var) -> Calc:
+def _transform_back(var_transformed: Var, monitor: bool) -> Calc:
     """
     Creates a :class:`.Calc` mapping a transformed parameter back to
     the original domain.
@@ -76,7 +76,9 @@ def _transform_back(var_transformed: Var) -> Calc:
     inputs = var_transformed.dist_node.inputs
     kwinputs = var_transformed.dist_node.kwinputs
 
-    return Calc(fn, var_transformed.value_node, *inputs, **kwinputs)  # type: ignore
+    new_calc = Calc(fn, var_transformed.value_node, *inputs, **kwinputs)  # type: ignore
+    new_calc.monitor = monitor
+    return new_calc
 
 
 class GraphBuilder:
@@ -685,7 +687,9 @@ class GraphBuilder:
         var_transformed.parameter = var.parameter
 
         # var is now the forward transformation (a weak node without distribution)
-        var.value_node = _transform_back(var_transformed)
+        var.value_node = _transform_back(
+            var_transformed, monitor=var.value_node.monitor
+        )
         var.dist_node = None
         var.parameter = False
 


### PR DESCRIPTION
I've implemented a hacky version to support the monitor flag specified in a liesel model in goose's EngineBuilder. It is not in the final stage because I want to try the implementation before creating a new Protocol class.

~~Currently, the change makes the test `test_sample_transformed_model` in `tests/model/test_goose.py` fail. I assume that is because the tuning requires the key to be tracked `mu_value` is not tracked.~~