### PR TITLE
Address #78

### DIFF
--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -506,7 +506,10 @@ class Calc(Node):
     def update(self) -> Calc:
         args = [_input.value for _input in self.inputs]
         kwargs = {kw: _input.value for kw, _input in self.kwinputs.items()}
-        self._value = self.function(*args, **kwargs)
+        try:
+            self._value = self.function(*args, **kwargs)
+        except Exception as e:
+            raise RuntimeError(f"Error while updating {self}.") from e
         self._outdated = False
         return self
 
@@ -518,7 +521,12 @@ class TransientCalc(TransientNode, Calc):
     def value(self) -> Any:
         args = [_input.value for _input in self.inputs]
         kwargs = {kw: _input.value for kw, _input in self.kwinputs.items()}
-        return self.function(*args, **kwargs)
+        try:
+            value = self.function(*args, **kwargs)
+        except Exception as e:
+            raise RuntimeError(f"Error while updating {self}.") from e
+
+        return value
 
 
 class TransientIdentity(TransientCalc):

--- a/tests/model/test_node.py
+++ b/tests/model/test_node.py
@@ -298,6 +298,36 @@ def test_n_to_n_calculator(Calc) -> None:
     assert np.allclose(calc.value, np.transpose(x_vec))
 
 
+def test_calculator_error_in_update() -> None:
+    x = Data(2.0, _name="x")
+
+    def update_fn(x):
+        raise ValueError("Testing error message.")
+
+    calc = Calc(update_fn, x=x)
+    with pytest.raises(RuntimeError):
+        calc.update()
+
+    calc = Calc(lambda x: x / 0, x=x)
+    with pytest.raises(RuntimeError):
+        calc.update()
+
+
+def test_transient_calculator_error_in_update() -> None:
+    x = Data(2.0, _name="x")
+
+    def update_fn(x):
+        raise ValueError("Testing error message.")
+
+    calc = TransientCalc(update_fn, x=x)
+    with pytest.raises(RuntimeError):
+        calc.value
+
+    calc = TransientCalc(lambda x: x / 0, x=x)
+    with pytest.raises(RuntimeError):
+        calc.value
+
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Test Dist, TransientDist ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/model/test_node.py
+++ b/tests/model/test_node.py
@@ -262,7 +262,7 @@ def test_calculator_kwinput_manipulation() -> None:
 
     calc.set_inputs(y=Data(1))
 
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         calc.update()
 
 
@@ -274,7 +274,7 @@ def test_transient_calculator_kwinput_manipulation() -> None:
 
     calc.set_inputs(y=Data(1))
 
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         calc.value
 
 


### PR DESCRIPTION
If an error occurs in a call to `Calc.update()`, the exception is now re-raised with a printout of the instance repr.

See #78 