### PR TITLE
Fix #103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [unreleased]
 
 - :sparkles: Improved the efficiency of the `liesel.distributions.mvn_degen.MultivariateNormalDegenerate.from_penalty` constructor (#101, @GianmarcoCallegher)
+- :construction: Added `observed=True` to a `pd.DataFrame.groupby()` call in `goose/summary_m.py` to silence a warning due to a deprecation in [pandas v2.1.0](https://pandas.pydata.org/docs/whatsnew/v2.1.0.html#deprecations)
 
 ## [0.2.5] - 2023-09-28
 

--- a/liesel/goose/summary_m.py
+++ b/liesel/goose/summary_m.py
@@ -388,7 +388,7 @@ class Summary:
         df["phase"] = pd.Categorical(df["phase"], categories=["warmup", "posterior"])
 
         df = df.set_index("phase", append=True)
-        df["chain"] = df.groupby(level=[0, 1, 2, 3]).cumcount()
+        df["chain"] = df.groupby(level=[0, 1, 2, 3], observed=True).cumcount()
         df = df.set_index("chain", append=True)
         df = df.sort_index()
 


### PR DESCRIPTION
Added `observed=True` to a `pd.DataFrame.groupby()` call in `goose/summary_m.py` to silence a warning due to a deprecation in [pandas v2.1.0](https://pandas.pydata.org/docs/whatsnew/v2.1.0.html#deprecations)