### PR TITLE
Expose sampling results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [unreleased]
 
 - :sparkles: The method `gs.Summary.error_df()` is now publicly available. (#137, @jobrachem)
+- :sparkles: The class `liesel.goose.engine.SamplingResults` is now exported via `liesel.goose`, which means it can be used as `gs.SamplingResults`. (@jobrachem)
 - :sparkles: Improved the efficiency of the `liesel.distributions.mvn_degen.MultivariateNormalDegenerate.from_penalty` constructor (#101, @GianmarcoCallegher)
 - :construction: Added `observed=True` to a `pd.DataFrame.groupby()` call in `goose/summary_m.py` to silence a warning due to a deprecation in [pandas v2.1.0](https://pandas.pydata.org/docs/whatsnew/v2.1.0.html#deprecations)
 - :construction: Renamed `lsl.Param` to `lsl.param` and `lsl.Obs` to `lsl.obs` to reflect the fact that those are functions, not classes. The old names are deprecated and scheduled for removal in v0.4.0. (#130, @jobrachem)

--- a/liesel/goose/__init__.py
+++ b/liesel/goose/__init__.py
@@ -4,6 +4,7 @@ Goose MCMC framework.
 
 from .builder import EngineBuilder as EngineBuilder
 from .engine import Engine as Engine
+from .engine import SamplingResults
 from .epoch import EpochConfig, EpochType
 from .gibbs import GibbsKernel
 from .hmc import HMCKernel
@@ -40,6 +41,7 @@ __all__ = [
     "Position",
     "RWKernel",
     "Summary",
+    "SamplingResults",
     "plot_cor",
     "plot_density",
     "plot_param",


### PR DESCRIPTION
The class `liesel.goose.engine.SamplingResults` was not being exported, which annoyed me whenever I wanted to load results from a pickled file via `SamplingResults.pkl_load()`.

It is now exported via `liesel.goose`, which means it can be used as `gs.SamplingResults`.