### PR TITLE
Add model and goose overview

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   release:
     types: [published]
+  pull_request:
+    branches: [main]
 
 jobs:
   docs:

--- a/docs/source/goose.rst
+++ b/docs/source/goose.rst
@@ -10,7 +10,7 @@ The import path for ``liesel.goose`` is::
 
     import liesel.goose as gs
 
-The workflow for MCMC sampling goose consists of two steps:
+The workflow for MCMC sampling goose consists of the following steps:
 
 1. Set up your model
 2. Set up an :class:`.Engine` with MCMC kernels for your parameters and draw posterior samples

--- a/docs/source/goose.rst
+++ b/docs/source/goose.rst
@@ -1,0 +1,109 @@
+.. _goose_overview:
+
+MCMC Sampling (liesel.goose)
+============================
+
+This is an overview of the most important building blocks for sampling from the
+posterior of your model ``liesel.goose``.
+
+The import path for ``liesel.goose`` is::
+
+    import liesel.goose as gs
+
+The workflow for MCMC sampling goose consists of two steps:
+
+1. Set up your model
+2. Set up an :class:`.Engine` with MCMC kernels for your parameters and draw posterior samples
+3. Inspect your results
+
+
+Set up your model
+-----------------
+
+A natural option for setting up your model is the use of ``liesel.model``. See
+:doc:`Model Building with liesel.model <model>` for more. However, you are not locked
+in to using :class:`.Model`. Goose currently includes the following interfaces:
+
+.. autosummary::
+    :toctree: generated
+    :recursive:
+    :nosignatures:
+
+    ~liesel.goose.interface.LieselInterface
+    ~liesel.goose.interface.DictInterface
+    ~liesel.goose.interface.DataclassInterface
+    ~liesel.experimental.pymc.PyMCInterface
+
+
+Set up an MCMC Engine and draw posterior samples
+------------------------------------------------
+
+To set up an MCMC engine, goose provides the :class:`.EngineBuilder`. Please refer to
+the linked EngineBuilder documentation to learn how to use it.
+
+.. autosummary::
+    :toctree: generated
+    :recursive:
+    :nosignatures:
+
+    ~liesel.goose.builder.EngineBuilder
+    ~liesel.goose.engine.Engine
+
+
+.. rubric:: Available MCMC kernels
+
+Goose makes it easy for you to combine different MCMC kernels for different blocks of
+model parameters. Currently, the available MCMC kernels are:
+
+.. autosummary::
+    :toctree: generated
+    :recursive:
+    :nosignatures:
+
+    ~liesel.goose.rw.RWKernel
+    ~liesel.goose.iwls.IWLSKernel
+    ~liesel.goose.hmc.HMCKernel
+    ~liesel.goose.nuts.NUTSKernel
+    ~liesel.goose.gibbs.GibbsKernel
+
+You can also define your own kernel by implementing the :class:`.Kernel` protocol.
+
+To draw samples from your posterior, you will want to call
+:meth:`.Engine.sample_all_epochs`. Once sampling is done, you can obtain the results
+with :meth:`.Engine.get_results`, which will return a :class:`.SamplingResults`
+instance.
+
+
+Inspect your results
+--------------------
+
+The two central classes for handling your sampling results are:
+
+.. autosummary::
+    :toctree: generated
+    :recursive:
+    :nosignatures:
+
+    ~liesel.goose.engine.SamplingResults
+    ~liesel.goose.summary_m.Summary
+
+You can obtain your posterior samples as a dictionary via
+:meth:`.SamplingResults.get_posterior_samples`. There is also experimental support
+for turning your samples into an ``arviz.InferenceData`` object via
+:func:`.to_arviz_inference_data`.
+
+.. rubric:: Plot posterior samples
+
+Goose comes with a number of plotting functions that give you quick acccess to important
+diagnostics.
+
+.. autosummary::
+    :toctree: generated
+    :recursive:
+    :nosignatures:
+
+    ~liesel.goose.summary_viz.plot_param
+    ~liesel.goose.summary_viz.plot_trace
+    ~liesel.goose.summary_viz.plot_density
+    ~liesel.goose.summary_viz.plot_pairs
+    ~liesel.goose.summary_viz.plot_cor

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,8 @@ Liesel: A Probabilistic Programming Framework
    :hidden:
    :maxdepth: 1
 
+   model
+   goose
    tutorials_overview
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,7 @@ Liesel: A Probabilistic Programming Framework
    :parser: myst_parser.sphinx_
 
 .. toctree::
+   :caption: Guides
    :hidden:
    :maxdepth: 1
 

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -1,0 +1,51 @@
+.. _model_overview:
+
+Model Building (liesel.model)
+=============================
+
+This is an overview of the most important building blocks for setting up your model
+graph with ``liesel.model``.
+
+The import path for ``liesel.model`` is::
+
+    import liesel.model as lsl
+
+
+The model building workflow in Liesel consists of two steps:
+
+1. Set up the nodes and variables that make up your model.
+2. Set up a :class:`.GraphBuilder`, add your root node(s) to it, and call :meth:`.GraphBuilder.build_model` to build your model graph.
+
+Nodes and Variables
+-------------------
+
+The fundamental building blocks of your model graph are given by just three classes
+and two functions. Each of these building blocks is documented with examples, so make
+sure to check them out.
+
+.. autosummary::
+    :toctree: generated
+    :recursive:
+    :nosignatures:
+
+    ~liesel.model.nodes.Data
+    ~liesel.model.nodes.Calc
+    ~liesel.model.nodes.Dist
+    ~liesel.model.nodes.obs
+    ~liesel.model.nodes.param
+
+
+Build and plot your model
+-------------------------
+
+The most important class here is the :class:`.GraphBuilder`.
+
+.. autosummary::
+    :toctree: generated
+    :recursive:
+    :nosignatures:
+
+    ~liesel.model.model.GraphBuilder
+    ~liesel.model.model.Model
+    ~liesel.model.viz.plot_vars
+    ~liesel.model.viz.plot_nodes

--- a/docs/source/welcome.md
+++ b/docs/source/welcome.md
@@ -28,6 +28,16 @@ $ pip install liesel
 If you want to work with the latest development version of Liesel or use PyGraphviz for
 prettier plots of the model graphs, see the [README][5] in the main repository.
 
+Now you can get started. We recommend using the following import paths:
+
+```python
+import liesel.model as lsl
+import liesel.goose as gs
+```
+
+We provide overviews of the most important building blocks provided by `liesel.model`
+and `liesel.goose` in [Model Building (liesel.model)](model_overview) and
+[MCMC Sampling (liesel.goose)](goose_overview), respectively.
 
 # Tutorials
 

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -83,29 +83,66 @@ def _transform_back(var_transformed: Var) -> Calc:
 
 class GraphBuilder:
     """
-    A graph builder to prepare a :class:`.Model`.
+    A graph builder, used to set up a :class:`.Model`.
 
     Constructs a model containing all nodes and variables that were added to the graph
-    builder and their recursive inputs. The outputs of the nodes are not added to the
-    model automatically, so the root nodes always need to be added explicitly.
+    builder and their recursive inputs.
 
-    The standard workflow is to create the nodes and variables, add them to a graph
-    builder, and construct a model from the graph builder. After the model has been
-    constructed, some methods of the graph builder are not available anymore.
+    .. important::
+        - In :meth:`.build_model` , the graph builder will automatically find all
+          **inputs** to its nodes - and the inputs to these inputs
+          (i.e. it finds inputs recursively).
+        - The **outputs** of the nodes, however, are not added to the model
+          automatically, so all **root nodes** need to be added explicitly.
+        - Root nodes are nodes that are not inputs to any other node in the graph.
+          The response in a regression model is an example of a root node.
 
-    Example
-    -------
+    The standard workflow is to create the nodes and variables, add the root var to a
+    graph builder, and construct a model from the graph builder. After the model has
+    been constructed, some methods of the graph builder are not available anymore,
+    because the graph is considered static.
+
+    See Also
+    --------
+
+    :class:`.Model` : The liesel model class, representing a static graph.
+    :meth:`.GraphBuilder.add` : Method for adding variables and nodes to the
+        GraphBuilder.
+    :meth:`.GraphBuilder.build_model` : Method for building a model from the
+        GraphBuilder.
+    :meth:`GraphBuilder.transform` : Transforms a variable by adding a new transformed
+        variable as an input. This is useful for variables that are constrained to a
+        certain domain, e.g. positive values.
+
+    Examples
+    --------
+
+    We start by creating some variables:
+
     >>> a = lsl.Var(1.0, name="a")
     >>> b = lsl.Var(2.0, name="b")
     >>> c = lsl.Var(lsl.Calc(lambda x, y: x + y, a, b), name="c")
+
+    We now initialize a GraphBuilder and add the root node ``c`` to it:
+
     >>> gb = lsl.GraphBuilder()
     >>> gb.add(c)
     GraphBuilder(0 nodes, 1 vars)
+
+    We are now ready to build the model:
+
     >>> model = gb.build_model()
     >>> model
     Model(9 nodes, 3 vars)
+
+    Note that when :meth:`.build_model` is called, all :attr:`~.Var.weak` variables in
+    the graph will be updated. So the value of ``c`` is now available:
+
     >>> c.value
     3.0
+
+    The graph builder is now empty:
+
     >>> gb.vars
     []
     """
@@ -241,9 +278,41 @@ class GraphBuilder:
 
         Parameters
         ----------
+        *args
+            The nodes, variables or graph builders to add to the graph. Note that \
+            the GraphBuilder will find input nodes recursively for all nodes and \
+            variables that are added to it, so you only need to add root nodes.
         to_float32
             Whether to convert the dtype of the values of the added nodes \
             from float64 to float32.
+
+        See Also
+        --------
+        :meth:`.GraphBuilder.build_model` : Method for building a model from the \
+            GraphBuilder.
+        :meth:`GraphBuilder.transform` : Transforms a variable by adding a new
+            transformed variable as an input.
+
+        Examples
+        --------
+
+        We start by creating some variables:
+
+        >>> a = lsl.Var(1.0, name="a")
+        >>> b = lsl.Var(2.0, name="b")
+        >>> c = lsl.Var(lsl.Calc(lambda x, y: x + y, a, b), name="c")
+
+        We now initialize a GraphBuilder and add the root node ``c`` to it:
+
+        >>> gb = lsl.GraphBuilder()
+        >>> gb.add(c)
+        GraphBuilder(0 nodes, 1 vars)
+
+        We are now ready to build the model:
+
+        >>> model = gb.build_model()
+        >>> model
+        Model(9 nodes, 3 vars)
         """
 
         for arg in args:
@@ -268,9 +337,15 @@ class GraphBuilder:
 
         Parameters
         ----------
+        *groups
+            The groups to add to the graph.
         to_float32
             Whether to convert the dtype of the values of the added nodes \
             from float64 to float32.
+
+        Returns
+        -------
+        The graph builder.
         """
 
         for group in groups:
@@ -294,40 +369,60 @@ class GraphBuilder:
         Builds a model from the graph.
 
         Constructs a model containing all nodes and variables that were added to the
-        graph builder and their recursive inputs. The outputs of the nodes are not
-        added to the model automatically, so the root nodes always need to be added
+        graph builder and their recursive inputs. The outputs of the nodes are not added
+        to the model automatically, so the root nodes always need to be added
         explicitly.
 
         The standard workflow is to create the nodes and variables, add them to a graph
         builder, and construct a model from the graph builder. After the model has been
         constructed, some methods of the graph builder are not available anymore.
 
-        Notes
-        -----
-        If this method is called with the argument ``copy=False``, all nodes and
-        variables are removed from the graph builder, because most methods of the
-        graph builder do not work with nodes that are part of a model.
-
-        Example
-        -------
-        >>> a = lsl.Var(1.0, name="a")
-        >>> b = lsl.Var(2.0, name="b")
-        >>> c = lsl.Var(lsl.Calc(lambda x, y: x + y, a, b), name="c")
-        >>> gb = lsl.GraphBuilder()
-        >>> gb.add(c)
-        GraphBuilder(0 nodes, 1 vars)
-        >>> model = gb.build_model()
-        >>> model
-        Model(9 nodes, 3 vars)
-        >>> c.value
-        3.0
-        >>> gb.vars
-        []
-
         Parameters
         ----------
         copy
             Whether the nodes and variables should be copied when building the model.
+
+        Returns
+        -------
+        The liesel model, which is a static graph built from the GraphBuilder.
+
+        Notes
+        -----
+        If this method is called with the argument ``copy=False``, all nodes and
+        variables are removed from the graph builder, because most methods of the graph
+        builder do not work with nodes that are part of a model.
+
+        Examples
+        --------
+
+        We start by creating some variables:
+
+        >>> a = lsl.Var(1.0, name="a")
+        >>> b = lsl.Var(2.0, name="b")
+        >>> c = lsl.Var(lsl.Calc(lambda x, y: x + y, a, b), name="c")
+
+        We now initialize a GraphBuilder and add the root node ``c`` to it:
+
+        >>> gb = lsl.GraphBuilder()
+        >>> gb.add(c)
+        GraphBuilder(0 nodes, 1 vars)
+
+        We are now ready to build the model:
+
+        >>> model = gb.build_model()
+        >>> model
+        Model(9 nodes, 3 vars)
+
+        Note that when :meth:`.build_model` is called, all :attr:`~.Var.weak` variables
+        in the graph will be updated. So the value of ``c`` is now available:
+
+        >>> c.value
+        3.0
+
+        The graph builder is now empty:
+
+        >>> gb.vars
+        []
         """
         nodes, _vars = self._all_nodes_and_vars()
 
@@ -377,6 +472,19 @@ class GraphBuilder:
         another type are silently ignored.
 
         .. _pytree: https://jax.readthedocs.io/en/latest/pytrees.html
+
+        Parameters
+        ----------
+        from_dtype
+            The data type to convert from.
+        to_dtype
+            The data type to convert to.
+
+        Returns
+        -------
+        The graph builder.
+
+
         """
         nodes, _ = self._all_nodes_and_vars()
 
@@ -441,7 +549,7 @@ class GraphBuilder:
 
     @property
     def log_lik_node(self) -> Node | None:
-        """The user-defined log-likelihood node."""
+        """User-defined log-likelihood node, if there is one."""
         return self._log_lik_node
 
     @log_lik_node.setter
@@ -453,7 +561,7 @@ class GraphBuilder:
 
     @property
     def log_prior_node(self) -> Node | None:
-        """The user-defined log-prior node."""
+        """User-defined log-prior node, if there is one."""
         return self._log_prior_node
 
     @log_prior_node.setter
@@ -465,7 +573,7 @@ class GraphBuilder:
 
     @property
     def log_prob_node(self) -> Node | None:
-        """The user-defined log-probability node."""
+        """User-defined log-probability node, if there is one."""
         return self._log_prob_node
 
     @log_prob_node.setter
@@ -476,7 +584,14 @@ class GraphBuilder:
         self._log_prob_node = log_prob_node
 
     def plot_nodes(self) -> GraphBuilder:
-        """Plots all nodes in the graph."""
+        """
+        Plots all nodes in the graph.
+
+        See Also
+        --------
+        :meth:`.viz.plot_nodes` : The function used to plot the nodes.
+
+        """
         nodes, _vars = self._all_nodes_and_vars()
         nodes_and_vars = nodes + _vars
 
@@ -489,7 +604,17 @@ class GraphBuilder:
         return self
 
     def plot_vars(self) -> GraphBuilder:
-        """Plots all variables in the graph."""
+        """
+        Plots all variables in the graph.
+
+        Returns
+        -------
+        The graph builder.
+
+        See Also
+        --------
+        :meth:`.viz.plot_vars` : The function used to plot the variables.
+        """
         nodes, _vars = self._all_nodes_and_vars()
         nodes_and_vars = nodes + _vars
 
@@ -596,6 +721,36 @@ class GraphBuilder:
             If the variable is weak, has no TFP distribution, the distribution has
             no default event space bijector and the argument ``bijector`` is ``None``,
             or the local model for the variable cannot be built.
+
+        Examples
+        --------
+
+        >>> import tensorflow_probability.substrates.jax.distributions as tfd
+        >>> import tensorflow_probability.substrates.jax.bijectors as tfb
+
+        Assume we have a variable ``scale`` that is constrained to be positive, and
+        we want to include the log-transformation of this variable in the model.
+        We first set up the parameter var with its distribution:
+
+        >>> prior = lsl.Dist(tfd.HalfCauchy, loc=0.0, scale=25.0)
+        >>> scale = lsl.param(1.0, prior, name="scale")
+
+        Then we create a GraphBuilder and use the ``transform`` method to transform
+        the ``scale`` variable.
+
+        >>> gb = lsl.GraphBuilder()
+        >>> log_scale = gb.transform(scale, bijector=tfb.Exp)
+        >>> log_scale
+        Var(name="scale_transformed")
+
+        Now the ``log_scale`` has a log probability, and the ``scale`` variable is
+        has not:
+
+        >>> log_scale.update().log_prob
+        Array(-3.6720574, dtype=float32)
+
+        >>> scale.update().log_prob
+        0.0
         """
 
         if var.weak:
@@ -702,7 +857,13 @@ class GraphBuilder:
         return var_transformed
 
     def update(self) -> GraphBuilder:
-        """Updates all nodes in the graph."""
+        """
+        Updates all nodes in the graph.
+
+        Returns
+        -------
+        The graph builder.
+        """
         nodes, _vars = self._all_nodes_and_vars()
         nodes_and_vars = nodes + _vars
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -458,7 +458,62 @@ class InputGroup(TransientNode):
 
 
 class Data(Node):
-    """A data node. Always up-to-date."""
+    """
+    A node that holds constant data.
+
+    Since the value represented by a data node does not change, it is always up-to-date.
+    A common usecase for data nodes is to cache computed values.
+
+    - By default, data nodes *will* appear in the node graph created by
+      :func:`.viz.plot_nodes`, but they will *not* appear in the model graph created by
+      :func:`.viz.plot_vars`.
+    - You can wrap a data node in a :class:`.Var` to make it appear in the model graph.
+
+    Parameters
+    ----------
+    value
+        The value of the data node.
+    _name
+        The name of the data node. If you do not specify a name, a unique name will be \
+        automatically generated upon initialization of a :class:`.Model`.
+
+    See Also
+    --------
+    .Calc :
+        A node representing a general calculation/operation
+        in JAX or Python.
+    .Dist :
+        A node representing a ``tensorflow_probability``
+        :class:`~tfp.distributions.Distribution`.
+    .Var : A variable in a statistical model, typically with a probability
+        distribution.
+    .param :
+        A helper function to initialize a :class:`.Var` as a model parameter.
+    .obs :
+        A helper function to initialize a :class:`.Var` as an observed variable.
+
+
+    Examples
+    --------
+
+    A simple data node representing a constant value without a name:
+
+    >>> nameless_node = lsl.Data(1.0)
+    >>> nameless_node
+    Data(name="")
+
+    Adding this node to a model leads to an automatically generated name:
+
+    >>> model = lsl.GraphBuilder().add(nameless_node).build_model()
+    >>> nameless_node
+    Data(name="n0")
+
+    A data node with a name:
+
+    >>> node = lsl.Data(1.0, _name="my_name")
+    >>> node
+    Data(name="my_name")
+    """
 
     def __init__(self, value: Any, _name: str = ""):
         super().__init__(_name=_name)

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -4,6 +4,7 @@ Nodes and variables.
 
 from __future__ import annotations
 
+import warnings
 import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Hashable, Iterable
@@ -16,7 +17,6 @@ import tensorflow_probability.substrates.jax.bijectors as jb
 import tensorflow_probability.substrates.jax.distributions as jd
 import tensorflow_probability.substrates.numpy.bijectors as nb
 import tensorflow_probability.substrates.numpy.distributions as nd
-from deprecated.sphinx import deprecated
 
 from ..distributions.nodist import NoDistribution
 
@@ -1548,21 +1548,31 @@ def param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-@deprecated(reason="Use the new `Group` object directly", version="0.2.2")
 def add_group(name: str, **kwargs: Node | Var) -> Group:
     """
     Assigns the nodes and variables to a group.
 
-    See :attr:`liesel.model.nodes.Node.groups`.
+    .. deprecated:: 0.2.2
+        Use the :class:`.Group` object directly. This function will be removed in
+        v0.4.0.
 
     Parameters
     ----------
     name
         The name of the group.
     kwargs
-        The nodes and variables in the group with their keys in the group
-        as keywords.
+        The nodes and variables in the group with their keys in the group as keywords.
+
+    See Also
+    --------
+    .Node.groups : The groups that a node is a part of.
+    .Group : A group of nodes and variables.
     """
+    warnings.warn(
+        "The `add_group` function is deprecated and will be removed in v0.4.0. "
+        "Use the `Group` object directly.",
+        FutureWarning,
+    )
     return Group(name, **kwargs)
 
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -459,7 +459,7 @@ class InputGroup(TransientNode):
 
 class Data(Node):
     """
-    A node that holds constant data.
+    A :class:`.Node` subclass that holds constant data.
 
     Since the value represented by a data node does not change, it is always up-to-date.
     A common usecase for data nodes is to cache computed values.
@@ -549,7 +549,7 @@ class Data(Node):
 
 class Calc(Node):
     """
-    A node that calculates its value based its inputs nodes.
+    A :class:`.Node` subclass that calculates its value based its inputs nodes.
 
     Calculator nodes are a central element block of the Liesel graph building toolkit.
     They wrap arbitrary calculations in pure JAX functions.
@@ -725,7 +725,7 @@ class VarValue(TransientIdentity):
 
 class Dist(Node):
     """
-    A distribution node.
+    A :class:`.Node` subclass that wraps a probability distribution.
 
     Distribution nodes wrap distribution classes that follow the
     ``tensorflow_probability`` :class:`~tfp.distributions.Distribution` interface.
@@ -1372,7 +1372,7 @@ class Var:
 
 def obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> Var:
     """
-    Declares an observed variable.
+    Helper function that returns an observed :class:`.Var`.
 
     Sets the :attr:`.Var.observed` flag. If the observed variable is a random variable,
     i.e. if it has an associated probability distribution, its log-probability is
@@ -1450,7 +1450,7 @@ def obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
 
 def param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> Var:
     """
-    Declares a parameter variable.
+    Helper function that returns a parameter :class:`.Var`.
 
     Sets the :attr:`.Var.parameter` flag. If the parameter variable is a
     random variable, i.e. if it has an associated probability distribution,

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -136,13 +136,20 @@ class Node(ABC):
     (see :attr:`.Model.state`), and can be stored in a chain by Liesel's MCMC engine
     Goose.
 
-    This class is an abstract class that cannot be initialized without defining the
-    :meth:`.update` method. See below for the most important concrete node classes.
+    .. note::
+        This class is an abstract class that cannot be initialized without defining the
+        :meth:`.update` method. See below for the most important concrete node classes.
 
-    Additional meta-information can be added by wrapping a :class:`.Data` or
-    :class:`.Calc` node in a :class:`.Var`, which is particularly useful if the node
-    represents a random variable, but can also be a good idea in a few other
-    situations.
+    Parameters
+    ----------
+    inputs
+        Non-keyword inputs. Any inputs that are not already nodes or :class:`.Var`
+        will be converted to :class:`.Data` nodes.
+    _name
+        The name of the node. If you do not specify a name, a unique name will be \
+        automatically generated upon initialization of a :class:`.Model`.
+    _needs_seed
+        Whether the node needs a seed / PRNG key.
 
     See Also
     --------
@@ -152,8 +159,14 @@ class Node(ABC):
     .Data :
         A node representing some static data.
     .Dist :
-        A node representing a `TensorFlow Probability`_ distribution,
-        typically for the evaluation of the log-probability.
+        A node representing a ``tensorflow_probability``
+        :class:`~tfp.distributions.Distribution`.
+    .Var : A variable in a statistical model, typically with a probability
+        distribution.
+    .param :
+        A helper function to initialize a :class:`.Var` as a model parameter.
+    .obs :
+        A helper function to initialize a :class:`.Var` as an observed variable.
 
 
     .. _pytrees: https://jax.readthedocs.io/en/latest/pytrees.html


### PR DESCRIPTION
Adds two overview pages that provide a focused selection of the most important and most frequently used functionality in liesel.model and liesel.goose, respectively.

For review, I am afraid the docs should be built and inspected locally.

This PR is built on top of 

- #143 

I think #143 should be reviewed first.