### PR TITLE
Allow passing key as seed

### DIFF
--- a/liesel/goose/builder.py
+++ b/liesel/goose/builder.py
@@ -130,7 +130,7 @@ class EngineBuilder:
     from your posterior distribution.
     """
 
-    def __init__(self, seed: int | jax.Array, num_chains: int):
+    def __init__(self, seed: int | KeyArray, num_chains: int):
         if isinstance(seed, int):
             keys = jax.random.split(jax.random.PRNGKey(seed), 3)
         elif isinstance(seed, jax.Array):

--- a/liesel/goose/builder.py
+++ b/liesel/goose/builder.py
@@ -72,6 +72,7 @@ class EngineBuilder:
     Parameters
     ----------
     seed
+        Either an int or a key generated from jax.random.PRNGKey.
         Used for jittering initial values and MCMC sampling.
     num_chains
         The number of chains to be used.
@@ -129,8 +130,16 @@ class EngineBuilder:
     from your posterior distribution.
     """
 
-    def __init__(self, seed: int, num_chains: int):
-        keys = jax.random.split(jax.random.PRNGKey(seed), 3)
+    def __init__(self, seed: int | jax.Array, num_chains: int):
+        if isinstance(seed, int):
+            keys = jax.random.split(jax.random.PRNGKey(seed), 3)
+        elif isinstance(seed, jax.Array):
+            keys = jax.random.split(seed, 3)
+        else:
+            raise TypeError(
+                "Provide either an int or a key from jax.random.PRNGKey as seed."
+            )
+
         self._prng_key: KeyArray = keys[0]
         self._engine_key: KeyArray = keys[1]
         self._jitter_key: KeyArray = keys[2]

--- a/tests/goose/test_builder.py
+++ b/tests/goose/test_builder.py
@@ -2,12 +2,24 @@
 some tests for the engine builder
 """
 
+import jax
 import jax.numpy as jnp
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 import liesel.goose as gs
 from liesel.goose.builder import EngineBuilder
 from liesel.goose.interface import DictInterface
+
+
+def test_seed_input():
+    int_seed = 0
+    key_seed = jax.random.PRNGKey(int_seed)
+    builder = EngineBuilder(seed=int_seed, num_chains=2)
+    builder2 = EngineBuilder(seed=key_seed, num_chains=2)
+
+    assert jnp.all(builder._prng_key == builder2._prng_key)
+    assert jnp.all(builder._engine_key == builder2._engine_key)
+    assert jnp.all(builder._jitter_key == builder2._jitter_key)
 
 
 def test_jitter_fns():


### PR DESCRIPTION
Simple proposal to allow `seed` argument to be a key generated from `jax.random.PRNGKey` in the initialization of class `EngineBuilder`. Unfortunately type testing for the key is not really strict with `jax.Array`. However using `jnp.issubdtype(seed.dtype, jnp.uint32)` makes it more complicated. Stricter type testing seems only possible with `jax.random.key` currently, see [#16716](https://github.com/google/jax/issues/16716) and [#16781](https://github.com/google/jax/pull/16781) for current development on this.