### PR TITLE
fix name `basis_matrix` in 07-groups.qmd

### DIFF
--- a/docs/source/tutorials/qmd/07-groups.qmd
+++ b/docs/source/tutorials/qmd/07-groups.qmd
@@ -197,7 +197,7 @@ class PSpline(lsl.Group):
             name=f"{name}_coef", penalty=penalty, tau2=tau2_group["tau2"]
         )
 
-        basis_matrix = lsl.obs(basis_matrix, name="basis_matrix")
+        basis_matrix = lsl.obs(basis_matrix, name=f"{name}_basis_matrix")
         smooth = lsl.Var(
             lsl.Calc(jnp.dot, basis_matrix, coef_group["coef"]), name=name
         )


### PR DESCRIPTION
Add format string to the name of `basis_matrix`, to allow for the unique definition of several B-spline basis matrices.