### PR TITLE
Rename Data -> Value; keep old name as an alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ cython_debug/
 
 # MacOS
 .DS_Store
+/tests/notebooks

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -35,7 +35,7 @@ sure to check them out.
     :nosignatures:
 
     ~liesel.model.nodes.Var
-    ~liesel.model.nodes.Data
+    ~liesel.model.nodes.Const
     ~liesel.model.nodes.Calc
     ~liesel.model.nodes.Dist
 

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -35,7 +35,7 @@ sure to check them out.
     :nosignatures:
 
     ~liesel.model.nodes.Var
-    ~liesel.model.nodes.Const
+    ~liesel.model.nodes.Value
     ~liesel.model.nodes.Calc
     ~liesel.model.nodes.Dist
 

--- a/docs/source/tutorials/md/01-lin-reg.md
+++ b/docs/source/tutorials/md/01-lin-reg.md
@@ -109,7 +109,7 @@ The graph of a Bayesian linear regression model is a tree, where the
 hyperparameters of the prior are the leaves and the response is the
 root. To build this tree in Liesel, we need to start from the leaves and
 work our way down to the root. As the basic building blocks of your
-model Liesel provides the {class}`.Node` classes {class}`.Data`,
+model Liesel provides the {class}`.Node` classes {class}`.Value`,
 {class}`.Calc`, and {class}`.Dist`, and the helper functions
 {func}`.obs` and {func}`.param`, which return instances of
 {class}`.Var`. See also [Model Building (liesel.model)](model_overview).
@@ -140,7 +140,7 @@ beta_prior = lsl.Dist(tfd.Normal, loc=0.0, scale=100.0)
 Note that you could also provide a {class}`.Node` or {class}`.Var`
 instance for the `loc` and `scale` argument - this fact allows you to
 build hierarchical models. If you provide floats like we do here, Liesel
-will turn them into {class}`.Data` nodes under the hood.
+will turn them into {class}`.Value` nodes under the hood.
 
 With this distribution object, we can now create the node for our
 regression coefficient with the {func}`.param` helper function:

--- a/docs/source/tutorials/md/07-groups.md
+++ b/docs/source/tutorials/md/07-groups.md
@@ -111,9 +111,9 @@ class SplineCoef(lsl.Group):
         penalty_var = lsl.Var(penalty, name=f"{name}_penalty")
 
         evals = jax.numpy.linalg.eigvalsh(penalty)
-        rank = lsl.Data(jnp.sum(evals > 0.0), _name=f"{name}_rank")
+        rank = lsl.Value(jnp.sum(evals > 0.0), _name=f"{name}_rank")
         _log_pdet = jnp.log(jnp.where(evals > 0.0, evals, 1.0)).sum()
-        log_pdet = lsl.Data(_log_pdet, _name=f"{name}_log_pdet")
+        log_pdet = lsl.Value(_log_pdet, _name=f"{name}_log_pdet")
 
         prior = lsl.Dist(
             MultivariateNormalDegenerate.from_penalty,

--- a/docs/source/tutorials/qmd/01-lin-reg.qmd
+++ b/docs/source/tutorials/qmd/01-lin-reg.qmd
@@ -91,7 +91,7 @@ plt.show()
 
 ### Building the model graph
 
-The graph of a Bayesian linear regression model is a tree, where the hyperparameters of the prior are the leaves and the response is the root. To build this tree in Liesel, we need to start from the leaves and work our way down to the root. As the basic building blocks of your model Liesel provides the {class}`.Node` classes {class}`.Data`, {class}`.Calc`, and {class}`.Dist`, and the helper functions {func}`.obs` and {func}`.param`, which return instances of {class}`.Var`. See also [Model Building (liesel.model)](model_overview).
+The graph of a Bayesian linear regression model is a tree, where the hyperparameters of the prior are the leaves and the response is the root. To build this tree in Liesel, we need to start from the leaves and work our way down to the root. As the basic building blocks of your model Liesel provides the {class}`.Node` classes {class}`.Value`, {class}`.Calc`, and {class}`.Dist`, and the helper functions {func}`.obs` and {func}`.param`, which return instances of {class}`.Var`. See also [Model Building (liesel.model)](model_overview).
 
 #### The regression coefficients
 
@@ -105,7 +105,7 @@ To do so, we need to define its initial value and its node distribution using th
 beta_prior = lsl.Dist(tfd.Normal, loc=0.0, scale=100.0)
 ```
 
-Note that you could also provide a {class}`.Node` or {class}`.Var` instance for the `loc` and `scale` argument - this fact allows you to build hierarchical models. If you provide floats like we do here, Liesel will turn them into {class}`.Data` nodes under the hood.
+Note that you could also provide a {class}`.Node` or {class}`.Var` instance for the `loc` and `scale` argument - this fact allows you to build hierarchical models. If you provide floats like we do here, Liesel will turn them into {class}`.Value` nodes under the hood.
 
 With this distribution object, we can now create the node for our regression coefficient with the {func}`.param` helper function:
 

--- a/docs/source/tutorials/qmd/07-groups.qmd
+++ b/docs/source/tutorials/qmd/07-groups.qmd
@@ -114,9 +114,9 @@ class SplineCoef(lsl.Group):
         penalty_var = lsl.Var(penalty, name=f"{name}_penalty")
 
         evals = jax.numpy.linalg.eigvalsh(penalty)
-        rank = lsl.Data(jnp.sum(evals > 0.0), _name=f"{name}_rank")
+        rank = lsl.Value(jnp.sum(evals > 0.0), _name=f"{name}_rank")
         _log_pdet = jnp.log(jnp.where(evals > 0.0, evals, 1.0)).sum()
-        log_pdet = lsl.Data(_log_pdet, _name=f"{name}_log_pdet")
+        log_pdet = lsl.Value(_log_pdet, _name=f"{name}_log_pdet")
 
         prior = lsl.Dist(
             MultivariateNormalDegenerate.from_penalty,

--- a/liesel/model/__init__.py
+++ b/liesel/model/__init__.py
@@ -25,6 +25,7 @@ from .model import GraphBuilder, Model, load_model, save_model
 from .nodes import (  # TODO: Bijector?
     Array,
     Calc,
+    Const,
     Data,
     Dist,
     Distribution,

--- a/liesel/model/__init__.py
+++ b/liesel/model/__init__.py
@@ -25,7 +25,6 @@ from .model import GraphBuilder, Model, load_model, save_model
 from .nodes import (  # TODO: Bijector?
     Array,
     Calc,
-    Const,
     Data,
     Dist,
     Distribution,
@@ -37,6 +36,7 @@ from .nodes import (  # TODO: Bijector?
     TransientDist,
     TransientIdentity,
     TransientNode,
+    Value,
     Var,
     add_group,
     obs,

--- a/liesel/model/goose.py
+++ b/liesel/model/goose.py
@@ -167,7 +167,7 @@ def finite_discrete_gibbs_kernel(
 
     Example for a variable with a Bernoulli prior distribution:
 
-    >>> prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Data(0.7))
+    >>> prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Value(0.7))
     >>> dummy_var = lsl.Var(
     ...     value=1,
     ...     distribution=prior,

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -946,9 +946,9 @@ class Model:
 
     >>> from pprint import pprint # for nicer formatting of the output dicts
     >>> pprint(nodes)
-    {'a_value': Data(name="a_value"),
+    {'a_value': Const(name="a_value"),
      'a_var_value': VarValue(name="a_var_value"),
-     'b_value': Data(name="b_value"),
+     'b_value': Const(name="b_value"),
      'b_var_value': VarValue(name="b_var_value"),
      'c_value': Calc(name="c_value"),
      'c_var_value': VarValue(name="c_var_value")}

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -27,13 +27,13 @@ from .nodes import (
     Array,
     Bijector,
     Calc,
-    Const,
     Dist,
     Group,
     InputGroup,
     Node,
     NodeState,
     TransientIdentity,
+    Value,
     Var,
     VarValue,
 )
@@ -207,7 +207,7 @@ class GraphBuilder:
 
         for node in nodes:
             if node.needs_seed:
-                seed = Const(jax.random.PRNGKey(0), _name=f"_model_{node.name}_seed")
+                seed = Value(jax.random.PRNGKey(0), _name=f"_model_{node.name}_seed")
                 node.set_inputs(*node.inputs, **{"seed": seed} | node.kwinputs)
 
         return self

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -946,9 +946,9 @@ class Model:
 
     >>> from pprint import pprint # for nicer formatting of the output dicts
     >>> pprint(nodes)
-    {'a_value': Const(name="a_value"),
+    {'a_value': Value(name="a_value"),
      'a_var_value': VarValue(name="a_var_value"),
-     'b_value': Const(name="b_value"),
+     'b_value': Value(name="b_value"),
      'b_var_value': VarValue(name="b_var_value"),
      'c_value': Calc(name="c_value"),
      'c_var_value': VarValue(name="c_var_value")}

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -27,7 +27,7 @@ from .nodes import (
     Array,
     Bijector,
     Calc,
-    Data,
+    Const,
     Dist,
     Group,
     InputGroup,
@@ -207,7 +207,7 @@ class GraphBuilder:
 
         for node in nodes:
             if node.needs_seed:
-                seed = Data(jax.random.PRNGKey(0), _name=f"_model_{node.name}_seed")
+                seed = Const(jax.random.PRNGKey(0), _name=f"_model_{node.name}_seed")
                 node.set_inputs(*node.inputs, **{"seed": seed} | node.kwinputs)
 
         return self

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -147,7 +147,7 @@ class Node(ABC):
     ----------
     inputs
         Non-keyword inputs. Any inputs that are not already nodes or :class:`.Var`
-        will be converted to :class:`.Data` nodes.
+        will be converted to :class:`.Const` nodes.
     _name
         The name of the node. If you do not specify a name, a unique name will be \
         automatically generated upon initialization of a :class:`.Model`.
@@ -159,7 +159,7 @@ class Node(ABC):
     .Calc :
         A node representing a general calculation/operation
         in JAX or Python.
-    .Data :
+    .Const :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``
@@ -359,7 +359,7 @@ class Node(ABC):
         """
         The value of the node.
 
-        Can only be set for a :class:`.Data` node, but not a :class:`.Calc` or
+        Can only be set for a :class:`.Const` node, but not a :class:`.Calc` or
         :class:`.Dist` node. If the node is part of a :class:`.Model` ``m`` with
         ``m.auto_update == True``, setting the value of the node triggers an update
         of the model. The auto-update can be disabled to improve the performance if
@@ -559,7 +559,7 @@ class Data(Const):
     See Also
     --------
     .Const :
-        Alias for :class:`.Data`. For full documentation, please consult
+        Alias for :class:`.Const`. For full documentation, please consult
         :class:`.Const`.
     """
 
@@ -593,7 +593,7 @@ class Calc(Node):
         The function to be wrapped. Must be jit-compilable by JAX.
     *inputs
         Non-keyword inputs. Any inputs that are not already nodes or :class:`.Var`
-        will be converted to :class:`.Data` nodes. The values of these inputs will be
+        will be converted to :class:`.Const` nodes. The values of these inputs will be
         passed to the wrapped function in the same order they are entered here.
     _name
         The name of the node. If you do not specify a name, a unique name will be \
@@ -605,12 +605,12 @@ class Calc(Node):
         initialization.
     **kwinputs
         Keyword inputs. Any inputs that are not already nodes or :class:`.Var`s
-        will be converted to :class:`.Data` nodes. The values of these inputs will be
+        will be converted to :class:`.Const` nodes. The values of these inputs will be
         passed to the wrapped function as keyword arguments.
 
     See Also
     --------
-    .Data :
+    .Const :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``
@@ -779,7 +779,7 @@ class Dist(Node):
         :class:`~tfp.distributions.Distribution` interface.
     *inputs
         Non-keyword inputs. Any inputs that are not already nodes or :class:`.Var`
-        will be converted to :class:`.Data` nodes. The values of these inputs will be
+        will be converted to :class:`.Const` nodes. The values of these inputs will be
         passed to the wrapped distribution in the same order they are entered here.
     _name
         The name of the node. If you do not specify a name, a unique name will be \
@@ -788,7 +788,7 @@ class Dist(Node):
         Whether the node needs a seed / PRNG key.
     **kwinputs
         Keyword inputs. Any inputs that are not already nodes or :class:`.Var`s
-        will be converted to :class:`.Data` nodes. The values of these inputs will be
+        will be converted to :class:`.Const` nodes. The values of these inputs will be
         passed to the wrapped distribution as keyword arguments.
 
     See Also
@@ -990,7 +990,7 @@ class Var:
     other nodes, e.g. structured additive predictors in semi-parametric
     regression models.
 
-    If a :class:`.Data` or :class:`.Calc` node does not have an associated probability
+    If a :class:`.Const` or :class:`.Calc` node does not have an associated probability
     distribution, it is possible but not necessary to declare it as a variable. There
     is no hard and fast rule when a node without a probability distribution should be
     declared as a variable and when not. The advantages of a variable in this case are:
@@ -1015,7 +1015,7 @@ class Var:
     .Calc :
         A node representing a general calculation/operation
         in JAX or Python.
-    .Data :
+    .Const :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``
@@ -1434,7 +1434,7 @@ def obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
     --------
     .Calc :
         A node representing a general calculation/operation in JAX or Python.
-    .Data :
+    .Const :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``
@@ -1513,7 +1513,7 @@ def param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
     .Calc :
         A node representing a general calculation/operation
         in JAX or Python.
-    .Data :
+    .Const :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -147,7 +147,7 @@ class Node(ABC):
     ----------
     inputs
         Non-keyword inputs. Any inputs that are not already nodes or :class:`.Var`
-        will be converted to :class:`.Const` nodes.
+        will be converted to :class:`.Value` nodes.
     _name
         The name of the node. If you do not specify a name, a unique name will be \
         automatically generated upon initialization of a :class:`.Model`.
@@ -159,7 +159,7 @@ class Node(ABC):
     .Calc :
         A node representing a general calculation/operation
         in JAX or Python.
-    .Const :
+    .Value :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``
@@ -359,7 +359,7 @@ class Node(ABC):
         """
         The value of the node.
 
-        Can only be set for a :class:`.Const` node, but not a :class:`.Calc` or
+        Can only be set for a :class:`.Value` node, but not a :class:`.Calc` or
         :class:`.Dist` node. If the node is part of a :class:`.Model` ``m`` with
         ``m.auto_update == True``, setting the value of the node triggers an update
         of the model. The auto-update can be disabled to improve the performance if
@@ -501,21 +501,21 @@ class Value(Node):
 
     A simple constant node representing a constant value without a name:
 
-    >>> nameless_node = lsl.Const(1.0)
+    >>> nameless_node = lsl.Value(1.0)
     >>> nameless_node
-    Const(name="")
+    Value(name="")
 
     Adding this node to a model leads to an automatically generated name:
 
     >>> model = lsl.GraphBuilder().add(nameless_node).build_model()
     >>> nameless_node
-    Const(name="n0")
+    Value(name="n0")
 
     A constant node with a name:
 
-    >>> node = lsl.Const(1.0, _name="my_name")
+    >>> node = lsl.Value(1.0, _name="my_name")
     >>> node
-    Const(name="my_name")
+    Value(name="my_name")
     """
 
     def __init__(self, value: Any, _name: str = ""):
@@ -554,13 +554,13 @@ class Data(Value):
     """
     A :class:`.Node` subclass that holds constant data.
 
-    This is an alias for :class:`.Const`.
+    This is an alias for :class:`.Value`.
 
     See Also
     --------
-    .Const :
-        Alias for :class:`.Const`. For full documentation, please consult
-        :class:`.Const`.
+    .Value :
+        Alias for :class:`.Value`. For full documentation, please consult
+        :class:`.Value`.
     """
 
     pass
@@ -593,7 +593,7 @@ class Calc(Node):
         The function to be wrapped. Must be jit-compilable by JAX.
     *inputs
         Non-keyword inputs. Any inputs that are not already nodes or :class:`.Var`
-        will be converted to :class:`.Const` nodes. The values of these inputs will be
+        will be converted to :class:`.Value` nodes. The values of these inputs will be
         passed to the wrapped function in the same order they are entered here.
     _name
         The name of the node. If you do not specify a name, a unique name will be \
@@ -605,12 +605,12 @@ class Calc(Node):
         initialization.
     **kwinputs
         Keyword inputs. Any inputs that are not already nodes or :class:`.Var`s
-        will be converted to :class:`.Const` nodes. The values of these inputs will be
+        will be converted to :class:`.Value` nodes. The values of these inputs will be
         passed to the wrapped function as keyword arguments.
 
     See Also
     --------
-    .Const :
+    .Value :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``
@@ -779,7 +779,7 @@ class Dist(Node):
         :class:`~tfp.distributions.Distribution` interface.
     *inputs
         Non-keyword inputs. Any inputs that are not already nodes or :class:`.Var`
-        will be converted to :class:`.Const` nodes. The values of these inputs will be
+        will be converted to :class:`.Value` nodes. The values of these inputs will be
         passed to the wrapped distribution in the same order they are entered here.
     _name
         The name of the node. If you do not specify a name, a unique name will be \
@@ -788,7 +788,7 @@ class Dist(Node):
         Whether the node needs a seed / PRNG key.
     **kwinputs
         Keyword inputs. Any inputs that are not already nodes or :class:`.Var`s
-        will be converted to :class:`.Const` nodes. The values of these inputs will be
+        will be converted to :class:`.Value` nodes. The values of these inputs will be
         passed to the wrapped distribution as keyword arguments.
 
     See Also
@@ -990,7 +990,7 @@ class Var:
     other nodes, e.g. structured additive predictors in semi-parametric
     regression models.
 
-    If a :class:`.Const` or :class:`.Calc` node does not have an associated probability
+    If a :class:`.Value` or :class:`.Calc` node does not have an associated probability
     distribution, it is possible but not necessary to declare it as a variable. There
     is no hard and fast rule when a node without a probability distribution should be
     declared as a variable and when not. The advantages of a variable in this case are:
@@ -1015,7 +1015,7 @@ class Var:
     .Calc :
         A node representing a general calculation/operation
         in JAX or Python.
-    .Const :
+    .Value :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``
@@ -1434,7 +1434,7 @@ def obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
     --------
     .Calc :
         A node representing a general calculation/operation in JAX or Python.
-    .Const :
+    .Value :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``
@@ -1513,7 +1513,7 @@ def param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
     .Calc :
         A node representing a general calculation/operation
         in JAX or Python.
-    .Const :
+    .Value :
         A node representing some static data.
     .Dist :
         A node representing a ``tensorflow_probability``

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -462,23 +462,24 @@ class InputGroup(TransientNode):
 
 class Value(Node):
     r"""
-    A :class:`.Node` subclass that holds constant data.
+    A :class:`.Node` subclass that holds constant values.
 
-    Since the value represented by a data node does not change, it is always up-to-date.
-    A common usecase for data nodes is to cache computed values.
+    Since the information represented by a value node does not change, it is
+    always up-to-date.
+    A common usecase for value nodes is to cache computed values.
 
-    - By default, constant nodes *will* appear in the node graph created by
+    - By default, value nodes *will* appear in the node graph created by
       :func:`.viz.plot_nodes`, but they will *not* appear in the model graph created by
       :func:`.viz.plot_vars`.
-    - You can wrap a constant node in a :class:`.Var` to make it appear in the model
+    - You can wrap a value node in a :class:`.Var` to make it appear in the model
       graph.
 
     Parameters
     ----------
     value
-        The value of the constant node.
+        The value of the node.
     _name
-        The name of the constant node. If you do not specify a name, a unique name will
+        The name of the node. If you do not specify a name, a unique name will
         be \ automatically generated upon initialization of a :class:`.Model`.
 
     See Also

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -28,7 +28,7 @@ __all__ = [
     "Array",
     "Bijector",
     "Calc",
-    "Const",
+    "Value",
     "Dist",
     "Distribution",
     "Group",
@@ -225,7 +225,7 @@ class Node(ABC):
             return x.var_value_node
 
         if not isinstance(x, Node):
-            return Const(x)
+            return Value(x)
 
         return x
 
@@ -460,7 +460,7 @@ class InputGroup(TransientNode):
         return ArgGroup(args, kwargs)
 
 
-class Const(Node):
+class Value(Node):
     r"""
     A :class:`.Node` subclass that holds constant data.
 
@@ -522,7 +522,7 @@ class Const(Node):
         super().__init__(_name=_name)
         self._value = value
 
-    def flag_outdated(self) -> Const:
+    def flag_outdated(self) -> Value:
         """Stops the recursion setting outdated flags."""
         return self
 
@@ -530,7 +530,7 @@ class Const(Node):
     def outdated(self) -> bool:
         return False
 
-    def update(self) -> Const:
+    def update(self) -> Value:
         """Does nothing."""
         return self
 
@@ -550,7 +550,7 @@ class Const(Node):
                 self.model.update()
 
 
-class Data(Const):
+class Data(Value):
     """
     A :class:`.Node` subclass that holds constant data.
 
@@ -1064,7 +1064,7 @@ class Var:
         name: str = "",
     ):
         self._name = name
-        self._value_node: Node = Const(None)
+        self._value_node: Node = Value(None)
         self._dist_node: Dist = NoDist()
 
         self._var_value_node: VarValue = VarValue(
@@ -1324,7 +1324,7 @@ class Var:
         .weak : Whether the variable is weak. In general, ``strong = not weak``.
 
         """
-        return isinstance(self.value_node, Const)
+        return isinstance(self.value_node, Value)
 
     def update(self) -> Var:
         """Updates the variable."""
@@ -1363,7 +1363,7 @@ class Var:
             value_node = Calc(lambda x: x, value_node)
 
         if not isinstance(value_node, Node):
-            value_node = Const(value_node)
+            value_node = Value(value_node)
 
         if value_node.model:
             raise RuntimeError(

--- a/tests/model/test_goose.py
+++ b/tests/model/test_goose.py
@@ -198,7 +198,7 @@ class TestFiniteDiscreteGibbsKernel:
     @pytest.mark.mcmc
     def test_sample_bernoulli(self):
         prior_prob = 0.7
-        prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Const(prior_prob))
+        prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Value(prior_prob))
         dummy_var = lsl.Var(
             value=1,
             distribution=prior,
@@ -228,7 +228,7 @@ class TestFiniteDiscreteGibbsKernel:
     @pytest.mark.mcmc
     def test_bernoulli_no_outcomes(self):
         prior_prob = 0.7
-        prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Const(prior_prob))
+        prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Value(prior_prob))
         dummy_var = lsl.Var(
             value=1,
             distribution=prior,

--- a/tests/model/test_goose.py
+++ b/tests/model/test_goose.py
@@ -198,7 +198,7 @@ class TestFiniteDiscreteGibbsKernel:
     @pytest.mark.mcmc
     def test_sample_bernoulli(self):
         prior_prob = 0.7
-        prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Data(prior_prob))
+        prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Const(prior_prob))
         dummy_var = lsl.Var(
             value=1,
             distribution=prior,
@@ -228,7 +228,7 @@ class TestFiniteDiscreteGibbsKernel:
     @pytest.mark.mcmc
     def test_bernoulli_no_outcomes(self):
         prior_prob = 0.7
-        prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Data(prior_prob))
+        prior = lsl.Dist(tfd.Bernoulli, probs=lsl.Const(prior_prob))
         dummy_var = lsl.Var(
             value=1,
             distribution=prior,

--- a/tests/model/test_graph_builder.py
+++ b/tests/model/test_graph_builder.py
@@ -11,7 +11,7 @@ import liesel.model.nodes as lnodes
 def test_transform() -> None:
     val = jnp.array((0.1, 1.0, 2.0))
     rate = 0.5
-    d_true = lnodes.Const(True, "true")
+    d_true = lnodes.Value(True, "true")
     dist = lnodes.Dist(tfp.distributions.Exponential, rate, validate_args=d_true)
     dist.per_obs = True
     var = lnodes.Var(val, dist)
@@ -69,7 +69,7 @@ def test_transform_with_param_outdated() -> None:
     val = jnp.array((0.1, 1.0, 2.0))
     real_rate = 1.5
     rate = lnodes.Calc(lambda x, y: x + y, 0.5, 1.0)
-    d_true = lnodes.Const(True, "true")
+    d_true = lnodes.Value(True, "true")
     dist = lnodes.Dist(tfp.distributions.Exponential, rate, validate_args=d_true)
     dist.per_obs = True
     var = lnodes.Var(val, dist)
@@ -119,7 +119,7 @@ def test_transform_with_param() -> None:
     val = jnp.array((0.1, 1.0, 2.0))
     real_rate = 1.5
     rate = lnodes.Calc(lambda x, y: x + y, 0.5, 1.0)
-    d_true = lnodes.Const(True, "true")
+    d_true = lnodes.Value(True, "true")
     dist = lnodes.Dist(tfp.distributions.Exponential, rate, validate_args=d_true)
     dist.per_obs = True
     var = lnodes.Var(val, dist)
@@ -170,7 +170,7 @@ def test_transform_with_param() -> None:
 def test_transform_user() -> None:
     val = jnp.array((0.1, 1.0, 2.0))
     rate = 0.5
-    d_true = lnodes.Const(True, "true")
+    d_true = lnodes.Value(True, "true")
     dist = lnodes.Dist(tfp.distributions.Exponential, rate, validate_args=d_true)
     dist.per_obs = True
     var = lnodes.Var(val, dist)
@@ -321,8 +321,8 @@ def test_add_same_group_twice() -> None:
 
 
 def test_manual_dtype_conversion(local_caplog) -> None:
-    float_node = lnodes.Const(np.zeros(5, dtype="float64"), _name="float_node")
-    int_node = lnodes.Const(np.zeros(5, dtype="int64"), _name="int_node")
+    float_node = lnodes.Value(np.zeros(5, dtype="float64"), _name="float_node")
+    int_node = lnodes.Value(np.zeros(5, dtype="int64"), _name="int_node")
 
     gb = lmodel.GraphBuilder()
     gb.add(float_node, int_node, to_float32=False)
@@ -337,7 +337,7 @@ def test_manual_dtype_conversion(local_caplog) -> None:
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "INFO"
         assert (
-            caplog.records[0].msg == 'Converted dtype of Const(name="float_node").value'
+            caplog.records[0].msg == 'Converted dtype of Value(name="float_node").value'
         )
 
     gb.convert_dtype("int64", "int32")
@@ -346,8 +346,8 @@ def test_manual_dtype_conversion(local_caplog) -> None:
 
 
 def test_auto_dtype_conversion() -> None:
-    float_node = lnodes.Const(np.zeros(5, dtype="float64"), _name="float_node")
-    int_node = lnodes.Const(np.zeros(5, dtype="int64"), _name="int_node")
+    float_node = lnodes.Value(np.zeros(5, dtype="float64"), _name="float_node")
+    int_node = lnodes.Value(np.zeros(5, dtype="int64"), _name="int_node")
 
     gb = lmodel.GraphBuilder()
     gb.add(float_node, int_node)

--- a/tests/model/test_graph_builder.py
+++ b/tests/model/test_graph_builder.py
@@ -11,7 +11,7 @@ import liesel.model.nodes as lnodes
 def test_transform() -> None:
     val = jnp.array((0.1, 1.0, 2.0))
     rate = 0.5
-    d_true = lnodes.Data(True, "true")
+    d_true = lnodes.Const(True, "true")
     dist = lnodes.Dist(tfp.distributions.Exponential, rate, validate_args=d_true)
     dist.per_obs = True
     var = lnodes.Var(val, dist)
@@ -69,7 +69,7 @@ def test_transform_with_param_outdated() -> None:
     val = jnp.array((0.1, 1.0, 2.0))
     real_rate = 1.5
     rate = lnodes.Calc(lambda x, y: x + y, 0.5, 1.0)
-    d_true = lnodes.Data(True, "true")
+    d_true = lnodes.Const(True, "true")
     dist = lnodes.Dist(tfp.distributions.Exponential, rate, validate_args=d_true)
     dist.per_obs = True
     var = lnodes.Var(val, dist)
@@ -119,7 +119,7 @@ def test_transform_with_param() -> None:
     val = jnp.array((0.1, 1.0, 2.0))
     real_rate = 1.5
     rate = lnodes.Calc(lambda x, y: x + y, 0.5, 1.0)
-    d_true = lnodes.Data(True, "true")
+    d_true = lnodes.Const(True, "true")
     dist = lnodes.Dist(tfp.distributions.Exponential, rate, validate_args=d_true)
     dist.per_obs = True
     var = lnodes.Var(val, dist)
@@ -170,7 +170,7 @@ def test_transform_with_param() -> None:
 def test_transform_user() -> None:
     val = jnp.array((0.1, 1.0, 2.0))
     rate = 0.5
-    d_true = lnodes.Data(True, "true")
+    d_true = lnodes.Const(True, "true")
     dist = lnodes.Dist(tfp.distributions.Exponential, rate, validate_args=d_true)
     dist.per_obs = True
     var = lnodes.Var(val, dist)
@@ -321,8 +321,8 @@ def test_add_same_group_twice() -> None:
 
 
 def test_manual_dtype_conversion(local_caplog) -> None:
-    float_node = lnodes.Data(np.zeros(5, dtype="float64"), _name="float_node")
-    int_node = lnodes.Data(np.zeros(5, dtype="int64"), _name="int_node")
+    float_node = lnodes.Const(np.zeros(5, dtype="float64"), _name="float_node")
+    int_node = lnodes.Const(np.zeros(5, dtype="int64"), _name="int_node")
 
     gb = lmodel.GraphBuilder()
     gb.add(float_node, int_node, to_float32=False)
@@ -337,7 +337,7 @@ def test_manual_dtype_conversion(local_caplog) -> None:
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "INFO"
         assert (
-            caplog.records[0].msg == 'Converted dtype of Data(name="float_node").value'
+            caplog.records[0].msg == 'Converted dtype of Const(name="float_node").value'
         )
 
     gb.convert_dtype("int64", "int32")
@@ -346,8 +346,8 @@ def test_manual_dtype_conversion(local_caplog) -> None:
 
 
 def test_auto_dtype_conversion() -> None:
-    float_node = lnodes.Data(np.zeros(5, dtype="float64"), _name="float_node")
-    int_node = lnodes.Data(np.zeros(5, dtype="int64"), _name="int_node")
+    float_node = lnodes.Const(np.zeros(5, dtype="float64"), _name="float_node")
+    int_node = lnodes.Const(np.zeros(5, dtype="int64"), _name="int_node")
 
     gb = lmodel.GraphBuilder()
     gb.add(float_node, int_node)

--- a/tests/model/test_group.py
+++ b/tests/model/test_group.py
@@ -1,6 +1,6 @@
 import pytest
 
-from liesel.model import Const, Group, Var
+from liesel.model import Group, Value, Var
 
 
 class TestGroup:
@@ -26,7 +26,7 @@ class TestGroup:
     def test_vars(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
-        n1 = Const(0.0)
+        n1 = Value(0.0)
 
         g = Group("test", var1=v1, var2=v2, nd1=n1)
 
@@ -37,7 +37,7 @@ class TestGroup:
     def test_nodes(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
-        n1 = Const(0.0)
+        n1 = Value(0.0)
 
         g = Group("test", var1=v1, var2=v2, nd1=n1)
 

--- a/tests/model/test_group.py
+++ b/tests/model/test_group.py
@@ -1,6 +1,6 @@
 import pytest
 
-from liesel.model import Data, Group, Var
+from liesel.model import Const, Group, Var
 
 
 class TestGroup:
@@ -26,7 +26,7 @@ class TestGroup:
     def test_vars(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
-        n1 = Data(0.0)
+        n1 = Const(0.0)
 
         g = Group("test", var1=v1, var2=v2, nd1=n1)
 
@@ -37,7 +37,7 @@ class TestGroup:
     def test_nodes(self) -> None:
         v1 = Var(0.0, name="v1")
         v2 = Var(0.0, name="v2")
-        n1 = Data(0.0)
+        n1 = Const(0.0)
 
         g = Group("test", var1=v1, var2=v2, nd1=n1)
 

--- a/tests/model/test_legacy.py
+++ b/tests/model/test_legacy.py
@@ -18,7 +18,7 @@ from liesel.model.legacy import (
     Smooth,
     SmoothingParam,
 )
-from liesel.model.nodes import Data, Dist, Var, param
+from liesel.model.nodes import Const, Dist, Var, param
 
 
 def test_design_matrix() -> None:
@@ -80,8 +80,8 @@ def test_smoothing_param() -> None:
 
 
 def test_addition() -> None:
-    a = Data(1.0, _name="a")
-    b = Data(2.0, _name="b")
+    a = Const(1.0, _name="a")
+    b = Const(2.0, _name="b")
     addition = Addition(a, b)
     addition.update()
 
@@ -89,8 +89,8 @@ def test_addition() -> None:
 
 
 def test_predictor() -> None:
-    a = Data(1.0, _name="a")
-    b = Data(2.0, _name="b")
+    a = Const(1.0, _name="a")
+    b = Const(2.0, _name="b")
     predictor = Predictor(a, b)
     predictor.update()
 
@@ -98,7 +98,7 @@ def test_predictor() -> None:
 
 
 def test_bijector() -> None:
-    a = Data(1.0, _name="a")
+    a = Const(1.0, _name="a")
     exp_bijector = Bijector(a, jb.Exp)
     exp_bijector.update()
 
@@ -111,7 +111,7 @@ def test_bijector() -> None:
 
 
 def test_inverse_link() -> None:
-    a = Data(0.5, _name="a")
+    a = Const(0.5, _name="a")
     log_inverse_link = InverseLink(a, jb.Log)
     log_inverse_link.update()
 
@@ -119,9 +119,9 @@ def test_inverse_link() -> None:
 
 
 def test_column_stack() -> None:
-    a = Data(13.0, _name="a")
-    b = Data(73.0, _name="b")
-    c = Data(10.0, _name="c")
+    a = Const(13.0, _name="a")
+    b = Const(73.0, _name="b")
+    c = Const(10.0, _name="c")
 
     cs = ColumnStack(a, b, c)
     cs.update()
@@ -130,12 +130,12 @@ def test_column_stack() -> None:
 
 
 def test_column_stack_with_distribution() -> None:
-    a = Data(1.0, _name="a")
-    b = Data(0.5, _name="b")
-    c = Data(0.0, _name="c")
+    a = Const(1.0, _name="a")
+    b = Const(0.5, _name="b")
+    c = Const(0.0, _name="c")
 
-    loc = Data(jnp.zeros(3), _name="loc")
-    cov = Data(jnp.eye(3), _name="cov")
+    loc = Const(jnp.zeros(3), _name="loc")
+    cov = Const(jnp.eye(3), _name="cov")
     dist = Dist(tfd.MultivariateNormalFullCovariance, loc, cov)
 
     cs = ColumnStack(a, b, c, distribution=dist)
@@ -151,8 +151,8 @@ def test_pit_var() -> None:
     with pytest.raises(RuntimeError):
         pit = PIT(x)
 
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     x.dist_node = dist
 
@@ -163,10 +163,10 @@ def test_pit_var() -> None:
 
 
 def test_pit_dist() -> None:
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
-    dist.at = Data(1.0, _name="x")
+    dist.at = Const(1.0, _name="x")
 
     pit = PIT(dist)
     pit.update()

--- a/tests/model/test_legacy.py
+++ b/tests/model/test_legacy.py
@@ -18,7 +18,7 @@ from liesel.model.legacy import (
     Smooth,
     SmoothingParam,
 )
-from liesel.model.nodes import Const, Dist, Var, param
+from liesel.model.nodes import Dist, Value, Var, param
 
 
 def test_design_matrix() -> None:
@@ -80,8 +80,8 @@ def test_smoothing_param() -> None:
 
 
 def test_addition() -> None:
-    a = Const(1.0, _name="a")
-    b = Const(2.0, _name="b")
+    a = Value(1.0, _name="a")
+    b = Value(2.0, _name="b")
     addition = Addition(a, b)
     addition.update()
 
@@ -89,8 +89,8 @@ def test_addition() -> None:
 
 
 def test_predictor() -> None:
-    a = Const(1.0, _name="a")
-    b = Const(2.0, _name="b")
+    a = Value(1.0, _name="a")
+    b = Value(2.0, _name="b")
     predictor = Predictor(a, b)
     predictor.update()
 
@@ -98,7 +98,7 @@ def test_predictor() -> None:
 
 
 def test_bijector() -> None:
-    a = Const(1.0, _name="a")
+    a = Value(1.0, _name="a")
     exp_bijector = Bijector(a, jb.Exp)
     exp_bijector.update()
 
@@ -111,7 +111,7 @@ def test_bijector() -> None:
 
 
 def test_inverse_link() -> None:
-    a = Const(0.5, _name="a")
+    a = Value(0.5, _name="a")
     log_inverse_link = InverseLink(a, jb.Log)
     log_inverse_link.update()
 
@@ -119,9 +119,9 @@ def test_inverse_link() -> None:
 
 
 def test_column_stack() -> None:
-    a = Const(13.0, _name="a")
-    b = Const(73.0, _name="b")
-    c = Const(10.0, _name="c")
+    a = Value(13.0, _name="a")
+    b = Value(73.0, _name="b")
+    c = Value(10.0, _name="c")
 
     cs = ColumnStack(a, b, c)
     cs.update()
@@ -130,12 +130,12 @@ def test_column_stack() -> None:
 
 
 def test_column_stack_with_distribution() -> None:
-    a = Const(1.0, _name="a")
-    b = Const(0.5, _name="b")
-    c = Const(0.0, _name="c")
+    a = Value(1.0, _name="a")
+    b = Value(0.5, _name="b")
+    c = Value(0.0, _name="c")
 
-    loc = Const(jnp.zeros(3), _name="loc")
-    cov = Const(jnp.eye(3), _name="cov")
+    loc = Value(jnp.zeros(3), _name="loc")
+    cov = Value(jnp.eye(3), _name="cov")
     dist = Dist(tfd.MultivariateNormalFullCovariance, loc, cov)
 
     cs = ColumnStack(a, b, c, distribution=dist)
@@ -151,8 +151,8 @@ def test_pit_var() -> None:
     with pytest.raises(RuntimeError):
         pit = PIT(x)
 
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     x.dist_node = dist
 
@@ -163,10 +163,10 @@ def test_pit_var() -> None:
 
 
 def test_pit_dist() -> None:
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
-    dist.at = Const(1.0, _name="x")
+    dist.at = Value(1.0, _name="x")
 
     pit = PIT(dist)
     pit.update()

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -10,7 +10,7 @@ import pytest
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from liesel.model.model import GraphBuilder, Model, save_model
-from liesel.model.nodes import Calc, Data, Dist, Group, TransientNode, Var, obs, param
+from liesel.model.nodes import Calc, Const, Dist, Group, TransientNode, Var, obs, param
 
 
 @pytest.fixture
@@ -82,15 +82,15 @@ def model(y_var) -> Generator:
     """
     A simple linear model with an additional unconnected data node for testing purposes.
     """
-    data = Data(2.5, "z")
+    data = Const(2.5, "z")
     yield Model([y_var, data])
 
 
 @pytest.fixture
 def model_nodes() -> Generator:
-    log_prior = Data(3.0, _name="_model_log_prior")
-    log_lik = Data(4.0, _name="_model_log_lik")
-    log_prob = Data(5.0, _name="_model_log_prob")
+    log_prior = Const(3.0, _name="_model_log_prior")
+    log_lik = Const(4.0, _name="_model_log_lik")
+    log_prob = Const(5.0, _name="_model_log_prob")
     model_nodes = [log_prob, log_prior, log_lik]
     yield model_nodes
 
@@ -352,7 +352,7 @@ class TestModel:
 @pytest.mark.xfail
 class TestUserDefinedModelNodes:
     @typing.no_type_check
-    def test_require_model_nodes(self, y_var: Var, model_nodes: list[Data]) -> None:
+    def test_require_model_nodes(self, y_var: Var, model_nodes: list[Const]) -> None:
         """
         Verifies that the model raises exceptions if any required model nodes are
         missing.
@@ -372,7 +372,7 @@ class TestUserDefinedModelNodes:
                 Model(variables=[y_var], nodes=comb, user_defined_model_nodes=True)
 
     @typing.no_type_check
-    def test_provide_model_nodes(self, y_var: Var, model_nodes: list[Data]) -> None:
+    def test_provide_model_nodes(self, y_var: Var, model_nodes: list[Const]) -> None:
         """
         Verifies that the model nodes are accepted if provided correctly.
         """
@@ -385,7 +385,7 @@ class TestUserDefinedModelNodes:
         assert model.log_prob == pytest.approx(5.0)
 
     @typing.no_type_check
-    def test_user_defined_false(self, y_var: Var, model_nodes: list[Data]) -> None:
+    def test_user_defined_false(self, y_var: Var, model_nodes: list[Const]) -> None:
         """
         Verifies that the model does not accept nodes with reserved names, if the
         flag user_defnied_model_nodes is set to False (default).

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -10,7 +10,7 @@ import pytest
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from liesel.model.model import GraphBuilder, Model, save_model
-from liesel.model.nodes import Calc, Const, Dist, Group, TransientNode, Var, obs, param
+from liesel.model.nodes import Calc, Dist, Group, TransientNode, Value, Var, obs, param
 
 
 @pytest.fixture
@@ -82,15 +82,15 @@ def model(y_var) -> Generator:
     """
     A simple linear model with an additional unconnected data node for testing purposes.
     """
-    data = Const(2.5, "z")
+    data = Value(2.5, "z")
     yield Model([y_var, data])
 
 
 @pytest.fixture
 def model_nodes() -> Generator:
-    log_prior = Const(3.0, _name="_model_log_prior")
-    log_lik = Const(4.0, _name="_model_log_lik")
-    log_prob = Const(5.0, _name="_model_log_prob")
+    log_prior = Value(3.0, _name="_model_log_prior")
+    log_lik = Value(4.0, _name="_model_log_lik")
+    log_prob = Value(5.0, _name="_model_log_prob")
     model_nodes = [log_prob, log_prior, log_lik]
     yield model_nodes
 
@@ -352,7 +352,7 @@ class TestModel:
 @pytest.mark.xfail
 class TestUserDefinedModelNodes:
     @typing.no_type_check
-    def test_require_model_nodes(self, y_var: Var, model_nodes: list[Const]) -> None:
+    def test_require_model_nodes(self, y_var: Var, model_nodes: list[Value]) -> None:
         """
         Verifies that the model raises exceptions if any required model nodes are
         missing.
@@ -372,7 +372,7 @@ class TestUserDefinedModelNodes:
                 Model(variables=[y_var], nodes=comb, user_defined_model_nodes=True)
 
     @typing.no_type_check
-    def test_provide_model_nodes(self, y_var: Var, model_nodes: list[Const]) -> None:
+    def test_provide_model_nodes(self, y_var: Var, model_nodes: list[Value]) -> None:
         """
         Verifies that the model nodes are accepted if provided correctly.
         """
@@ -385,7 +385,7 @@ class TestUserDefinedModelNodes:
         assert model.log_prob == pytest.approx(5.0)
 
     @typing.no_type_check
-    def test_user_defined_false(self, y_var: Var, model_nodes: list[Const]) -> None:
+    def test_user_defined_false(self, y_var: Var, model_nodes: list[Value]) -> None:
         """
         Verifies that the model does not accept nodes with reserved names, if the
         flag user_defnied_model_nodes is set to False (default).

--- a/tests/model/test_node.py
+++ b/tests/model/test_node.py
@@ -7,11 +7,11 @@ import tensorflow_probability.substrates.numpy.distributions as tfd
 from liesel.model.model import Model
 from liesel.model.nodes import (
     Calc,
-    Const,
     Dist,
     NodeState,
     TransientCalc,
     TransientDist,
+    Value,
     Var,
 )
 
@@ -21,14 +21,14 @@ from liesel.model.nodes import (
 
 
 def test_data_var() -> None:
-    x = Const(1.0, _name="x")
+    x = Value(1.0, _name="x")
     v1 = Var(value=x)
 
     assert x.var is v1
 
 
 def test_data_init() -> None:
-    x = Const(0.0, _name="node")
+    x = Value(0.0, _name="node")
 
     assert x.value == pytest.approx(0.0)
     assert x.name == "node"
@@ -39,7 +39,7 @@ def test_data_init() -> None:
 
 
 def test_data_clear_state() -> None:
-    x = Const(1.0, _name="x")
+    x = Value(1.0, _name="x")
     x.clear_state()
 
     assert not x.outdated
@@ -47,7 +47,7 @@ def test_data_clear_state() -> None:
 
 
 def test_data_state_manipulation() -> None:
-    x = Const(0.0, _name="x")
+    x = Value(0.0, _name="x")
     x.state = NodeState(1.0, True)
     x.name = "n"
     x.update()
@@ -58,7 +58,7 @@ def test_data_state_manipulation() -> None:
 
 
 def test_data() -> None:
-    x = Const(13.0, _name="x")
+    x = Value(13.0, _name="x")
 
     assert x.value == pytest.approx(13.0)
     assert not x.outdated
@@ -70,7 +70,7 @@ def test_data() -> None:
 
 
 def test_frozen_data_name_manipulation() -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     x.update()
 
     with pytest.raises(RuntimeError):
@@ -79,7 +79,7 @@ def test_frozen_data_name_manipulation() -> None:
 
 
 def test_frozen_data_needs_seed_manipulation() -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     x.update()
 
     with pytest.raises(RuntimeError):
@@ -94,7 +94,7 @@ def test_frozen_data_needs_seed_manipulation() -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_var(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     v1 = Var(value=calc)
 
@@ -103,7 +103,7 @@ def test_calculator_var(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_init(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     id_all_inputs = {id(i) for i in calc.all_input_nodes()}
 
@@ -112,7 +112,7 @@ def test_calculator_init(Calc) -> None:
 
 
 def test_calculator_clear_state() -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.clear_state()
 
@@ -121,7 +121,7 @@ def test_calculator_clear_state() -> None:
 
 
 def test_transient_calculator_clear_state() -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = TransientCalc(np.exp, x)
     calc.clear_state()
 
@@ -130,7 +130,7 @@ def test_transient_calculator_clear_state() -> None:
 
 
 def test_calculator_state_manipulation() -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.state = NodeState(1.0, True)
 
@@ -143,7 +143,7 @@ def test_calculator_state_manipulation() -> None:
 
 
 def test_transient_calculator_state_manipulation() -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = TransientCalc(np.exp, x)
     calc.state = NodeState(1.0, True)
 
@@ -158,7 +158,7 @@ def test_transient_calculator_state_manipulation() -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_arg_input_nodes(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     id_all_inputs = {id(i) for i in calc.all_input_nodes()}
 
@@ -167,7 +167,7 @@ def test_calculator_arg_input_nodes(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_kwarg_input_nodes(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x=x)
     id_all_inputs = {id(i) for i in calc.all_input_nodes()}
 
@@ -176,11 +176,11 @@ def test_calculator_kwarg_input_nodes(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_manipulated_calculator_input_nodes(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
-    y = Const(3.0, _name="y")
+    y = Value(3.0, _name="y")
     calc.set_inputs(y)
     id_all_inputs = {id(i) for i in calc.all_input_nodes()}
 
@@ -189,7 +189,7 @@ def test_manipulated_calculator_input_nodes(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_univariate_calculator(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -198,7 +198,7 @@ def test_univariate_calculator(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_frozen_calc_name_manipulation(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -209,7 +209,7 @@ def test_frozen_calc_name_manipulation(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_frozen_calc_needs_seed_manipulation(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -220,7 +220,7 @@ def test_frozen_calc_needs_seed_manipulation(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_frozen_calculator_function_manipulation(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -231,7 +231,7 @@ def test_frozen_calculator_function_manipulation(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_frozen_calculator_kwinputs_manipulation(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -240,16 +240,16 @@ def test_frozen_calculator_kwinputs_manipulation(Calc) -> None:
         calc.set_inputs()
 
     with pytest.raises(RuntimeError):
-        calc.set_inputs(y=Const(1.0))
+        calc.set_inputs(y=Value(1.0))
 
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_input_manipulation(Calc) -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
-    y = Const(1.0, _name="y")
+    y = Value(1.0, _name="y")
     calc.set_inputs(y)
     calc.update()
 
@@ -257,24 +257,24 @@ def test_calculator_input_manipulation(Calc) -> None:
 
 
 def test_calculator_kwinput_manipulation() -> None:
-    x = Const(2, _name="x")
+    x = Value(2, _name="x")
     calc = Calc(lambda x: x, x=x)
     calc.update()
     assert calc.value == 2
 
-    calc.set_inputs(y=Const(1))
+    calc.set_inputs(y=Value(1))
 
     with pytest.raises(RuntimeError):
         calc.update()
 
 
 def test_transient_calculator_kwinput_manipulation() -> None:
-    x = Const(2, _name="x")
+    x = Value(2, _name="x")
     calc = TransientCalc(lambda x: x, x=x)
     calc.update()
     assert calc.value == 2
 
-    calc.set_inputs(y=Const(1))
+    calc.set_inputs(y=Value(1))
 
     with pytest.raises(RuntimeError):
         calc.value
@@ -283,7 +283,7 @@ def test_transient_calculator_kwinput_manipulation() -> None:
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_n_to_1_calculator(Calc) -> None:
     x_vec = np.array([1.0, 2.0])
-    x = Const(x_vec, _name="x")
+    x = Value(x_vec, _name="x")
     calc = Calc(np.linalg.norm, x)
     calc.update()
 
@@ -293,7 +293,7 @@ def test_n_to_1_calculator(Calc) -> None:
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_n_to_n_calculator(Calc) -> None:
     x_vec = np.array([[0, 1, 2], [3, 4, 5], [7, 8, 9]])
-    x = Const(x_vec, _name="x")
+    x = Value(x_vec, _name="x")
     calc = Calc(np.transpose, x)
     calc.update()
 
@@ -301,7 +301,7 @@ def test_n_to_n_calculator(Calc) -> None:
 
 
 def test_calculator_error_in_update() -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
 
     def update_fn(x):
         raise ValueError("Testing error message.")
@@ -316,7 +316,7 @@ def test_calculator_error_in_update() -> None:
 
 
 def test_transient_calculator_error_in_update() -> None:
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
 
     def update_fn(x):
         raise ValueError("Testing error message.")
@@ -334,7 +334,7 @@ def test_calculator_update_on_init_error(local_caplog) -> None:
     def _raise_error(a):
         raise RuntimeError("Testing Error")
 
-    a = Data(1.0)
+    a = Value(1.0)
     with local_caplog() as caplog:
         Calc(_raise_error, a)
         assert "was not updated during initialization" in caplog.records[0].message
@@ -352,7 +352,7 @@ def test_calculator_update_on_init_error(local_caplog) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_update_on_init(Calc, local_caplog) -> None:
-    a = Data(0.0)
+    a = Value(0.0)
     b = Calc(np.exp, a)
     assert b.value == pytest.approx(1.0)
 
@@ -364,8 +364,8 @@ def test_calculator_update_on_init(Calc, local_caplog) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_var(Dist) -> None:
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     v1 = Var(value=dist)
 
@@ -374,9 +374,9 @@ def test_distribution_var(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_init(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     id_all_inputs = {id(i) for i in dist.all_input_nodes()}
@@ -387,9 +387,9 @@ def test_distribution_init(Dist) -> None:
 
 
 def test_distribution_clear_state() -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.clear_state()
@@ -399,9 +399,9 @@ def test_distribution_clear_state() -> None:
 
 
 def test_transient_distribution_clear_state() -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = TransientDist(tfd.Normal, loc, scale)
     dist.at = x
     dist.clear_state()
@@ -411,9 +411,9 @@ def test_transient_distribution_clear_state() -> None:
 
 
 def test_distribution_state_manipulation() -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.state = NodeState(1.0, True)
@@ -427,9 +427,9 @@ def test_distribution_state_manipulation() -> None:
 
 
 def test_transient_distribution_state_manipulation() -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = TransientDist(tfd.Normal, loc, scale)
     dist.at = x
     dist.state = NodeState(1.0, True)
@@ -445,9 +445,9 @@ def test_transient_distribution_state_manipulation() -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_arg_all_input_nodes(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     id_all_inputs = {id(i) for i in dist.all_input_nodes()}
@@ -457,9 +457,9 @@ def test_distribution_arg_all_input_nodes(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_kwarg_all_input_nodes(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc=loc, scale=scale)
     dist.at = x
     id_all_inputs = {id(i) for i in dist.all_input_nodes()}
@@ -469,14 +469,14 @@ def test_distribution_kwarg_all_input_nodes(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_manipulated_distribution_all_input_nodes(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc=loc, scale=scale)
     dist.at = x
     dist.update()
 
-    y = Const(3.0, _name="y")
+    y = Value(3.0, _name="y")
     dist.at = y
     id_all_inputs = {id(i) for i in dist.all_input_nodes()}
 
@@ -485,9 +485,9 @@ def test_manipulated_distribution_all_input_nodes(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_univariate_distribution(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -498,9 +498,9 @@ def test_univariate_distribution(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_name_manipulation(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -512,9 +512,9 @@ def test_frozen_distribution_name_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_needs_seed_manipulation(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -526,9 +526,9 @@ def test_frozen_distribution_needs_seed_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_distribution_manipulation(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -540,14 +540,14 @@ def test_frozen_distribution_distribution_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_inputs_manipulation(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
 
-    rate = Const(1.0, _name="rate")
+    rate = Value(1.0, _name="rate")
 
     with pytest.raises(RuntimeError):
         _ = Model([dist])
@@ -556,9 +556,9 @@ def test_frozen_distribution_inputs_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_kwinputs_manipulation(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -568,22 +568,22 @@ def test_frozen_distribution_kwinputs_manipulation(Dist) -> None:
         dist.set_inputs()
 
     with pytest.raises(RuntimeError):
-        dist.set_inputs(rate=Const(1.0))
+        dist.set_inputs(rate=Value(1.0))
 
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_input_manipulation(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
 
-    rate = Const(1.0, _name="rate")
+    rate = Value(1.0, _name="rate")
     dist.distribution = tfd.Exponential
     dist.set_inputs(rate)
-    x = Const(2.0, _name="x")
+    x = Value(2.0, _name="x")
     dist.at = x
     dist.update()
 
@@ -594,16 +594,16 @@ def test_distribution_input_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_kwinput_manipulation(Dist) -> None:
-    x = Const(1.0, _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value(1.0, _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
 
     dist.distribution = tfd.Exponential
-    dist.set_inputs(rate=Const(1.0))
-    x = Const(2.0, _name="x")
+    dist.set_inputs(rate=Value(1.0))
+    x = Value(2.0, _name="x")
     dist.at = x
     dist.update()
 
@@ -614,9 +614,9 @@ def test_distribution_kwinput_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_univariate_batched_distribution(Dist) -> None:
-    x = Const([1.0, 2.0], _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value([1.0, 2.0], _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.per_obs = True
@@ -627,9 +627,9 @@ def test_univariate_batched_distribution(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_univariate_batched_distribution_per_obs_false(Dist) -> None:
-    x = Const([1.0, 2.0], _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value([1.0, 2.0], _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.per_obs = True
@@ -641,9 +641,9 @@ def test_univariate_batched_distribution_per_obs_false(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_univariate_batched_distribution_per_obs_default(Dist) -> None:
-    x = Const([1.0, 2.0], _name="x")
-    loc = Const(0.0, _name="loc")
-    scale = Const(1.0, _name="scale")
+    x = Value([1.0, 2.0], _name="x")
+    loc = Value(0.0, _name="loc")
+    scale = Value(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -657,9 +657,9 @@ def test_multivariate_distribution(Dist) -> None:
     x_vec = np.array([1.0, 0.5])
     loc_vec = np.array([0.0, 0.5])
     scale_m = np.identity(2)
-    x = Const(x_vec, _name="x")
-    loc = Const(loc_vec, _name="loc")
-    scale = Const(scale_m, _name="scale")
+    x = Value(x_vec, _name="x")
+    loc = Value(loc_vec, _name="loc")
+    scale = Value(scale_m, _name="scale")
     dist = Dist(tfd.MultivariateNormalFullCovariance, loc, scale)
     dist.at = x
     dist.update()
@@ -674,11 +674,11 @@ def test_multivariate_distribution(Dist) -> None:
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_multivariate_batched_distribution(Dist) -> None:
     x_vec = np.array([[1.0, 0.5], [0.3, 0.8]])
-    x = Const(x_vec, _name="x")
+    x = Value(x_vec, _name="x")
     loc_vec = np.array([0.0, 0.5])
     scale_m = np.identity(2)
-    loc = Const(loc_vec, _name="loc")
-    scale = Const(scale_m, _name="scale")
+    loc = Value(loc_vec, _name="loc")
+    scale = Value(scale_m, _name="scale")
     dist = Dist(tfd.MultivariateNormalFullCovariance, loc, scale)
     dist.at = x
     dist.per_obs = True

--- a/tests/model/test_node.py
+++ b/tests/model/test_node.py
@@ -7,7 +7,7 @@ import tensorflow_probability.substrates.numpy.distributions as tfd
 from liesel.model.model import Model
 from liesel.model.nodes import (
     Calc,
-    Data,
+    Const,
     Dist,
     NodeState,
     TransientCalc,
@@ -21,14 +21,14 @@ from liesel.model.nodes import (
 
 
 def test_data_var() -> None:
-    x = Data(1.0, _name="x")
+    x = Const(1.0, _name="x")
     v1 = Var(value=x)
 
     assert x.var is v1
 
 
 def test_data_init() -> None:
-    x = Data(0.0, _name="node")
+    x = Const(0.0, _name="node")
 
     assert x.value == pytest.approx(0.0)
     assert x.name == "node"
@@ -39,7 +39,7 @@ def test_data_init() -> None:
 
 
 def test_data_clear_state() -> None:
-    x = Data(1.0, _name="x")
+    x = Const(1.0, _name="x")
     x.clear_state()
 
     assert not x.outdated
@@ -47,7 +47,7 @@ def test_data_clear_state() -> None:
 
 
 def test_data_state_manipulation() -> None:
-    x = Data(0.0, _name="x")
+    x = Const(0.0, _name="x")
     x.state = NodeState(1.0, True)
     x.name = "n"
     x.update()
@@ -58,7 +58,7 @@ def test_data_state_manipulation() -> None:
 
 
 def test_data() -> None:
-    x = Data(13.0, _name="x")
+    x = Const(13.0, _name="x")
 
     assert x.value == pytest.approx(13.0)
     assert not x.outdated
@@ -70,7 +70,7 @@ def test_data() -> None:
 
 
 def test_frozen_data_name_manipulation() -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     x.update()
 
     with pytest.raises(RuntimeError):
@@ -79,7 +79,7 @@ def test_frozen_data_name_manipulation() -> None:
 
 
 def test_frozen_data_needs_seed_manipulation() -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     x.update()
 
     with pytest.raises(RuntimeError):
@@ -94,7 +94,7 @@ def test_frozen_data_needs_seed_manipulation() -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_var(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     v1 = Var(value=calc)
 
@@ -103,7 +103,7 @@ def test_calculator_var(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_init(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     id_all_inputs = {id(i) for i in calc.all_input_nodes()}
 
@@ -112,7 +112,7 @@ def test_calculator_init(Calc) -> None:
 
 
 def test_calculator_clear_state() -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.clear_state()
 
@@ -121,7 +121,7 @@ def test_calculator_clear_state() -> None:
 
 
 def test_transient_calculator_clear_state() -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = TransientCalc(np.exp, x)
     calc.clear_state()
 
@@ -130,7 +130,7 @@ def test_transient_calculator_clear_state() -> None:
 
 
 def test_calculator_state_manipulation() -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.state = NodeState(1.0, True)
 
@@ -143,7 +143,7 @@ def test_calculator_state_manipulation() -> None:
 
 
 def test_transient_calculator_state_manipulation() -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = TransientCalc(np.exp, x)
     calc.state = NodeState(1.0, True)
 
@@ -158,7 +158,7 @@ def test_transient_calculator_state_manipulation() -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_arg_input_nodes(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     id_all_inputs = {id(i) for i in calc.all_input_nodes()}
 
@@ -167,7 +167,7 @@ def test_calculator_arg_input_nodes(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_kwarg_input_nodes(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x=x)
     id_all_inputs = {id(i) for i in calc.all_input_nodes()}
 
@@ -176,11 +176,11 @@ def test_calculator_kwarg_input_nodes(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_manipulated_calculator_input_nodes(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
-    y = Data(3.0, _name="y")
+    y = Const(3.0, _name="y")
     calc.set_inputs(y)
     id_all_inputs = {id(i) for i in calc.all_input_nodes()}
 
@@ -189,7 +189,7 @@ def test_manipulated_calculator_input_nodes(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_univariate_calculator(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -198,7 +198,7 @@ def test_univariate_calculator(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_frozen_calc_name_manipulation(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -209,7 +209,7 @@ def test_frozen_calc_name_manipulation(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_frozen_calc_needs_seed_manipulation(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -220,7 +220,7 @@ def test_frozen_calc_needs_seed_manipulation(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_frozen_calculator_function_manipulation(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -231,7 +231,7 @@ def test_frozen_calculator_function_manipulation(Calc) -> None:
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_frozen_calculator_kwinputs_manipulation(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
@@ -240,16 +240,16 @@ def test_frozen_calculator_kwinputs_manipulation(Calc) -> None:
         calc.set_inputs()
 
     with pytest.raises(RuntimeError):
-        calc.set_inputs(y=Data(1.0))
+        calc.set_inputs(y=Const(1.0))
 
 
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_calculator_input_manipulation(Calc) -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     calc = Calc(np.exp, x)
     calc.update()
 
-    y = Data(1.0, _name="y")
+    y = Const(1.0, _name="y")
     calc.set_inputs(y)
     calc.update()
 
@@ -257,24 +257,24 @@ def test_calculator_input_manipulation(Calc) -> None:
 
 
 def test_calculator_kwinput_manipulation() -> None:
-    x = Data(2, _name="x")
+    x = Const(2, _name="x")
     calc = Calc(lambda x: x, x=x)
     calc.update()
     assert calc.value == 2
 
-    calc.set_inputs(y=Data(1))
+    calc.set_inputs(y=Const(1))
 
     with pytest.raises(RuntimeError):
         calc.update()
 
 
 def test_transient_calculator_kwinput_manipulation() -> None:
-    x = Data(2, _name="x")
+    x = Const(2, _name="x")
     calc = TransientCalc(lambda x: x, x=x)
     calc.update()
     assert calc.value == 2
 
-    calc.set_inputs(y=Data(1))
+    calc.set_inputs(y=Const(1))
 
     with pytest.raises(RuntimeError):
         calc.value
@@ -283,7 +283,7 @@ def test_transient_calculator_kwinput_manipulation() -> None:
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_n_to_1_calculator(Calc) -> None:
     x_vec = np.array([1.0, 2.0])
-    x = Data(x_vec, _name="x")
+    x = Const(x_vec, _name="x")
     calc = Calc(np.linalg.norm, x)
     calc.update()
 
@@ -293,7 +293,7 @@ def test_n_to_1_calculator(Calc) -> None:
 @pytest.mark.parametrize("Calc", [Calc, TransientCalc])
 def test_n_to_n_calculator(Calc) -> None:
     x_vec = np.array([[0, 1, 2], [3, 4, 5], [7, 8, 9]])
-    x = Data(x_vec, _name="x")
+    x = Const(x_vec, _name="x")
     calc = Calc(np.transpose, x)
     calc.update()
 
@@ -301,7 +301,7 @@ def test_n_to_n_calculator(Calc) -> None:
 
 
 def test_calculator_error_in_update() -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
 
     def update_fn(x):
         raise ValueError("Testing error message.")
@@ -316,7 +316,7 @@ def test_calculator_error_in_update() -> None:
 
 
 def test_transient_calculator_error_in_update() -> None:
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
 
     def update_fn(x):
         raise ValueError("Testing error message.")
@@ -364,8 +364,8 @@ def test_calculator_update_on_init(Calc, local_caplog) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_var(Dist) -> None:
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     v1 = Var(value=dist)
 
@@ -374,9 +374,9 @@ def test_distribution_var(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_init(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     id_all_inputs = {id(i) for i in dist.all_input_nodes()}
@@ -387,9 +387,9 @@ def test_distribution_init(Dist) -> None:
 
 
 def test_distribution_clear_state() -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.clear_state()
@@ -399,9 +399,9 @@ def test_distribution_clear_state() -> None:
 
 
 def test_transient_distribution_clear_state() -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = TransientDist(tfd.Normal, loc, scale)
     dist.at = x
     dist.clear_state()
@@ -411,9 +411,9 @@ def test_transient_distribution_clear_state() -> None:
 
 
 def test_distribution_state_manipulation() -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.state = NodeState(1.0, True)
@@ -427,9 +427,9 @@ def test_distribution_state_manipulation() -> None:
 
 
 def test_transient_distribution_state_manipulation() -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = TransientDist(tfd.Normal, loc, scale)
     dist.at = x
     dist.state = NodeState(1.0, True)
@@ -445,9 +445,9 @@ def test_transient_distribution_state_manipulation() -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_arg_all_input_nodes(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     id_all_inputs = {id(i) for i in dist.all_input_nodes()}
@@ -457,9 +457,9 @@ def test_distribution_arg_all_input_nodes(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_kwarg_all_input_nodes(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc=loc, scale=scale)
     dist.at = x
     id_all_inputs = {id(i) for i in dist.all_input_nodes()}
@@ -469,14 +469,14 @@ def test_distribution_kwarg_all_input_nodes(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_manipulated_distribution_all_input_nodes(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc=loc, scale=scale)
     dist.at = x
     dist.update()
 
-    y = Data(3.0, _name="y")
+    y = Const(3.0, _name="y")
     dist.at = y
     id_all_inputs = {id(i) for i in dist.all_input_nodes()}
 
@@ -485,9 +485,9 @@ def test_manipulated_distribution_all_input_nodes(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_univariate_distribution(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -498,9 +498,9 @@ def test_univariate_distribution(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_name_manipulation(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -512,9 +512,9 @@ def test_frozen_distribution_name_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_needs_seed_manipulation(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -526,9 +526,9 @@ def test_frozen_distribution_needs_seed_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_distribution_manipulation(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -540,14 +540,14 @@ def test_frozen_distribution_distribution_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_inputs_manipulation(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
 
-    rate = Data(1.0, _name="rate")
+    rate = Const(1.0, _name="rate")
 
     with pytest.raises(RuntimeError):
         _ = Model([dist])
@@ -556,9 +556,9 @@ def test_frozen_distribution_inputs_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_frozen_distribution_kwinputs_manipulation(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -568,22 +568,22 @@ def test_frozen_distribution_kwinputs_manipulation(Dist) -> None:
         dist.set_inputs()
 
     with pytest.raises(RuntimeError):
-        dist.set_inputs(rate=Data(1.0))
+        dist.set_inputs(rate=Const(1.0))
 
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_input_manipulation(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
 
-    rate = Data(1.0, _name="rate")
+    rate = Const(1.0, _name="rate")
     dist.distribution = tfd.Exponential
     dist.set_inputs(rate)
-    x = Data(2.0, _name="x")
+    x = Const(2.0, _name="x")
     dist.at = x
     dist.update()
 
@@ -594,16 +594,16 @@ def test_distribution_input_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_distribution_kwinput_manipulation(Dist) -> None:
-    x = Data(1.0, _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const(1.0, _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
 
     dist.distribution = tfd.Exponential
-    dist.set_inputs(rate=Data(1.0))
-    x = Data(2.0, _name="x")
+    dist.set_inputs(rate=Const(1.0))
+    x = Const(2.0, _name="x")
     dist.at = x
     dist.update()
 
@@ -614,9 +614,9 @@ def test_distribution_kwinput_manipulation(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_univariate_batched_distribution(Dist) -> None:
-    x = Data([1.0, 2.0], _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const([1.0, 2.0], _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.per_obs = True
@@ -627,9 +627,9 @@ def test_univariate_batched_distribution(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_univariate_batched_distribution_per_obs_false(Dist) -> None:
-    x = Data([1.0, 2.0], _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const([1.0, 2.0], _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.per_obs = True
@@ -641,9 +641,9 @@ def test_univariate_batched_distribution_per_obs_false(Dist) -> None:
 
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_univariate_batched_distribution_per_obs_default(Dist) -> None:
-    x = Data([1.0, 2.0], _name="x")
-    loc = Data(0.0, _name="loc")
-    scale = Data(1.0, _name="scale")
+    x = Const([1.0, 2.0], _name="x")
+    loc = Const(0.0, _name="loc")
+    scale = Const(1.0, _name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     dist.at = x
     dist.update()
@@ -657,9 +657,9 @@ def test_multivariate_distribution(Dist) -> None:
     x_vec = np.array([1.0, 0.5])
     loc_vec = np.array([0.0, 0.5])
     scale_m = np.identity(2)
-    x = Data(x_vec, _name="x")
-    loc = Data(loc_vec, _name="loc")
-    scale = Data(scale_m, _name="scale")
+    x = Const(x_vec, _name="x")
+    loc = Const(loc_vec, _name="loc")
+    scale = Const(scale_m, _name="scale")
     dist = Dist(tfd.MultivariateNormalFullCovariance, loc, scale)
     dist.at = x
     dist.update()
@@ -674,11 +674,11 @@ def test_multivariate_distribution(Dist) -> None:
 @pytest.mark.parametrize("Dist", [Dist, TransientDist])
 def test_multivariate_batched_distribution(Dist) -> None:
     x_vec = np.array([[1.0, 0.5], [0.3, 0.8]])
-    x = Data(x_vec, _name="x")
+    x = Const(x_vec, _name="x")
     loc_vec = np.array([0.0, 0.5])
     scale_m = np.identity(2)
-    loc = Data(loc_vec, _name="loc")
-    scale = Data(scale_m, _name="scale")
+    loc = Const(loc_vec, _name="loc")
+    scale = Const(scale_m, _name="scale")
     dist = Dist(tfd.MultivariateNormalFullCovariance, loc, scale)
     dist.at = x
     dist.per_obs = True

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -13,10 +13,10 @@ def test_initialization() -> None:
     assert var0.value == 0
     assert var0.dist_node is None
     assert var0.name == ""
-    assert isinstance(var0.value_node, lnodes.Data)
+    assert isinstance(var0.value_node, lnodes.Const)
 
     # simple data variable with specified nodes
-    dat = lnodes.Data(1)
+    dat = lnodes.Const(1)
     dist = lnodes.Dist(lnodes.NoDistribution())
     var1 = lnodes.Var(dat, dist, "foo")
     assert id(var1.value_node) == id(dat)
@@ -109,8 +109,8 @@ def test_info() -> None:
 
 
 def test_value_node() -> None:
-    node0 = lnodes.Data(0.0)
-    node1 = lnodes.Data(0.0)
+    node0 = lnodes.Const(0.0)
+    node1 = lnodes.Const(0.0)
     var = lnodes.Var(node0, None)
 
     assert var.value_node is node0
@@ -150,7 +150,7 @@ def test_property_strong_node() -> None:
 
 
 def test_property_weak_node() -> None:
-    in0 = lnodes.Data(0.0)
+    in0 = lnodes.Const(0.0)
     calc = lnodes.Calc(lambda x: x, in0)
     var = lnodes.Var(calc, None)
 
@@ -175,7 +175,7 @@ def test_read_value() -> None:
     assert var0.value == 0
 
     # weak node
-    in0 = lnodes.Data(0)
+    in0 = lnodes.Const(0)
     calc = lnodes.Calc(lambda x: x + 1, in0)
     var1 = lnodes.Var(calc, None)
 
@@ -191,7 +191,7 @@ def test_write_value() -> None:
     assert var0.value == 1
 
     # weak node
-    in0 = lnodes.Data(0)
+    in0 = lnodes.Const(0)
     calc = lnodes.Calc(lambda x: x + 1, in0)
     var1 = lnodes.Var(calc, None)
     with pytest.raises(RuntimeError):
@@ -222,7 +222,7 @@ def test_auto_transform():
 
 
 def test_method_nodes() -> None:
-    in0 = lnodes.Data(0)
+    in0 = lnodes.Const(0)
     calc = lnodes.Calc(lambda x: x + 1, in0)
     dist = lnodes.Dist(lnodes.NoDistribution())
     var0 = lnodes.Var(calc, dist)
@@ -272,13 +272,13 @@ def test_all_input_nodes_strong_no_dist():
 
 
 def test_all_input_nodes_weak_no_dist():
-    x = lnodes.Data(1)
+    x = lnodes.Const(1)
     var = lnodes.Var(lnodes.Calc(lambda x: x + 1, x))
     assert len(var.all_input_nodes()) == 1
 
 
 def test_all_input_nodes_weak_no_dist_2():
-    x = lnodes.Data(1)
+    x = lnodes.Const(1)
     var = lnodes.Var(
         lnodes.Calc(
             lambda x, y: x + y,
@@ -290,8 +290,8 @@ def test_all_input_nodes_weak_no_dist_2():
 
 
 def test_all_input_nodes_weak_no_dist_3():
-    x = lnodes.Data(1)
-    y = lnodes.Data(2)
+    x = lnodes.Const(1)
+    y = lnodes.Const(2)
     var = lnodes.Var(
         lnodes.Calc(
             lambda x, y: x + y,
@@ -311,7 +311,7 @@ def test_all_input_nodes_strong_w_dist():
 
 def test_all_input_nodes_weak_w_dist():
     dist = lnodes.Dist(tfp.distributions.Normal, loc=0.0, scale=1.0)
-    x = lnodes.Data(1)
+    x = lnodes.Const(1)
     var = lnodes.Var(lnodes.Calc(lambda x: x + 1, x), dist)
     assert len(var.all_input_nodes()) == 4
 
@@ -319,7 +319,7 @@ def test_all_input_nodes_weak_w_dist():
 def test_all_input_nodes_weak_w_dist_2():
     dist = lnodes.Dist(tfp.distributions.Normal, loc=0.0, scale=1.0)
 
-    x = lnodes.Data(1)
+    x = lnodes.Const(1)
     var = lnodes.Var(
         lnodes.Calc(
             lambda x, y: x + y,
@@ -333,8 +333,8 @@ def test_all_input_nodes_weak_w_dist_2():
 
 def test_all_input_nodes_weak_w_dist_3():
     dist = lnodes.Dist(tfp.distributions.Normal, loc=0.0, scale=1.0)
-    x = lnodes.Data(1)
-    y = lnodes.Data(2)
+    x = lnodes.Const(1)
+    y = lnodes.Const(2)
     var = lnodes.Var(
         lnodes.Calc(
             lambda x, y: x + y,
@@ -402,7 +402,7 @@ def test_all_input_vars_weak_w_dist_1():
 
     x = lnodes.Var(1)
     y = lnodes.Var(1)
-    z_node = lnodes.Data(1)
+    z_node = lnodes.Const(1)
     var = lnodes.Var(lnodes.Calc(lambda x: x + 1, x), dist_mk())
     assert len(var.all_input_vars()) == 3
 
@@ -422,7 +422,7 @@ def test_all_input_vars_weak_w_dist_2():
 
     x = lnodes.Var(1)
     y = lnodes.Var(1)
-    z_node = lnodes.Data(1)
+    z_node = lnodes.Const(1)
     var = lnodes.Var(lnodes.Calc(lambda x: x + 1, x), dist_mk())
     assert len(var.all_input_vars()) == 1
 

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -13,10 +13,10 @@ def test_initialization() -> None:
     assert var0.value == 0
     assert var0.dist_node is None
     assert var0.name == ""
-    assert isinstance(var0.value_node, lnodes.Const)
+    assert isinstance(var0.value_node, lnodes.Value)
 
     # simple data variable with specified nodes
-    dat = lnodes.Const(1)
+    dat = lnodes.Value(1)
     dist = lnodes.Dist(lnodes.NoDistribution())
     var1 = lnodes.Var(dat, dist, "foo")
     assert id(var1.value_node) == id(dat)
@@ -109,8 +109,8 @@ def test_info() -> None:
 
 
 def test_value_node() -> None:
-    node0 = lnodes.Const(0.0)
-    node1 = lnodes.Const(0.0)
+    node0 = lnodes.Value(0.0)
+    node1 = lnodes.Value(0.0)
     var = lnodes.Var(node0, None)
 
     assert var.value_node is node0
@@ -150,7 +150,7 @@ def test_property_strong_node() -> None:
 
 
 def test_property_weak_node() -> None:
-    in0 = lnodes.Const(0.0)
+    in0 = lnodes.Value(0.0)
     calc = lnodes.Calc(lambda x: x, in0)
     var = lnodes.Var(calc, None)
 
@@ -175,7 +175,7 @@ def test_read_value() -> None:
     assert var0.value == 0
 
     # weak node
-    in0 = lnodes.Const(0)
+    in0 = lnodes.Value(0)
     calc = lnodes.Calc(lambda x: x + 1, in0)
     var1 = lnodes.Var(calc, None)
 
@@ -191,7 +191,7 @@ def test_write_value() -> None:
     assert var0.value == 1
 
     # weak node
-    in0 = lnodes.Const(0)
+    in0 = lnodes.Value(0)
     calc = lnodes.Calc(lambda x: x + 1, in0)
     var1 = lnodes.Var(calc, None)
     with pytest.raises(RuntimeError):
@@ -222,7 +222,7 @@ def test_auto_transform():
 
 
 def test_method_nodes() -> None:
-    in0 = lnodes.Const(0)
+    in0 = lnodes.Value(0)
     calc = lnodes.Calc(lambda x: x + 1, in0)
     dist = lnodes.Dist(lnodes.NoDistribution())
     var0 = lnodes.Var(calc, dist)
@@ -272,13 +272,13 @@ def test_all_input_nodes_strong_no_dist():
 
 
 def test_all_input_nodes_weak_no_dist():
-    x = lnodes.Const(1)
+    x = lnodes.Value(1)
     var = lnodes.Var(lnodes.Calc(lambda x: x + 1, x))
     assert len(var.all_input_nodes()) == 1
 
 
 def test_all_input_nodes_weak_no_dist_2():
-    x = lnodes.Const(1)
+    x = lnodes.Value(1)
     var = lnodes.Var(
         lnodes.Calc(
             lambda x, y: x + y,
@@ -290,8 +290,8 @@ def test_all_input_nodes_weak_no_dist_2():
 
 
 def test_all_input_nodes_weak_no_dist_3():
-    x = lnodes.Const(1)
-    y = lnodes.Const(2)
+    x = lnodes.Value(1)
+    y = lnodes.Value(2)
     var = lnodes.Var(
         lnodes.Calc(
             lambda x, y: x + y,
@@ -311,7 +311,7 @@ def test_all_input_nodes_strong_w_dist():
 
 def test_all_input_nodes_weak_w_dist():
     dist = lnodes.Dist(tfp.distributions.Normal, loc=0.0, scale=1.0)
-    x = lnodes.Const(1)
+    x = lnodes.Value(1)
     var = lnodes.Var(lnodes.Calc(lambda x: x + 1, x), dist)
     assert len(var.all_input_nodes()) == 4
 
@@ -319,7 +319,7 @@ def test_all_input_nodes_weak_w_dist():
 def test_all_input_nodes_weak_w_dist_2():
     dist = lnodes.Dist(tfp.distributions.Normal, loc=0.0, scale=1.0)
 
-    x = lnodes.Const(1)
+    x = lnodes.Value(1)
     var = lnodes.Var(
         lnodes.Calc(
             lambda x, y: x + y,
@@ -333,8 +333,8 @@ def test_all_input_nodes_weak_w_dist_2():
 
 def test_all_input_nodes_weak_w_dist_3():
     dist = lnodes.Dist(tfp.distributions.Normal, loc=0.0, scale=1.0)
-    x = lnodes.Const(1)
-    y = lnodes.Const(2)
+    x = lnodes.Value(1)
+    y = lnodes.Value(2)
     var = lnodes.Var(
         lnodes.Calc(
             lambda x, y: x + y,
@@ -402,7 +402,7 @@ def test_all_input_vars_weak_w_dist_1():
 
     x = lnodes.Var(1)
     y = lnodes.Var(1)
-    z_node = lnodes.Const(1)
+    z_node = lnodes.Value(1)
     var = lnodes.Var(lnodes.Calc(lambda x: x + 1, x), dist_mk())
     assert len(var.all_input_vars()) == 3
 
@@ -422,7 +422,7 @@ def test_all_input_vars_weak_w_dist_2():
 
     x = lnodes.Var(1)
     y = lnodes.Var(1)
-    z_node = lnodes.Const(1)
+    z_node = lnodes.Value(1)
     var = lnodes.Var(lnodes.Calc(lambda x: x + 1, x), dist_mk())
     assert len(var.all_input_vars()) == 1
 


### PR DESCRIPTION
This PR goes back to a suggestion made by @Seb-Lorek :

>I find the naming of the node "Data" a bit unfortunate. I would have thought of Fixed or something like that. When you think of Data, you generally think of oberved data in the model. Also the description: "A Node subclass that holds constant data.". Doesn't help, it reminded me more of observed data. (Thought the description somehow fit: "Constant values better.")

I am not sure whether I am entirely happy with `Const`, because this class is also used as the `lsl.Var.value_node` of strong variables. If they are parameters, the values are not actually constant, but updated during sampling. So maybe `Value` would be better than `Const`. What do you guys think @GianmarcoCallegher @wiep? Of course this PR is not super urgent, so no need to prioritise it right now,