### PR TITLE
Make transform a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - :construction: Fixed spurious warning during model creation (#186, @jobrachem)
 - :construction: Update logging setup (#187, @jobrachem)
+- :sparkles: New method `Var.transform`. (#174, @jobrachem)
 
 ## [0.2.9] - 2024-04-04
 

--- a/docs/source/tutorials/qmd/01a-transform.qmd
+++ b/docs/source/tutorials/qmd/01a-transform.qmd
@@ -66,13 +66,13 @@ y_dist = lsl.Dist(tfd.Normal, loc=mu, scale=sigma)
 y = lsl.Var(y_vec, distribution=y_dist, name="y")
 ```
 
-Now let's try to sample the full parameter vector $(\boldsymbol{\beta}', \sigma)'$ with a single NUTS kernel instead of using a NUTS kernel for $\boldsymbol{\beta}$ and a Gibbs kernel for $\sigma^2$. Since the standard deviation is a positive-valued parameter, we need to log-transform it to sample it with a NUTS kernel. The {class}`.GraphBuilder` class provides the {meth}`.transform_parameter` method for this purpose.
+Now let's try to sample the full parameter vector $(\boldsymbol{\beta}', \sigma)'$ with a single NUTS kernel instead of using a NUTS kernel for $\boldsymbol{\beta}$ and a Gibbs kernel for $\sigma^2$. Since the standard deviation is a positive-valued parameter, we need to log-transform it to sample it with a NUTS kernel. The {class}`.Var` class provides the {meth}`.Var.transform` method for this purpose.
 
 ```{python}
 #| label: graph-and-transformation
-gb = lsl.GraphBuilder().add(y)
-gb.transform(sigma_sq, tfb.Exp)
+sigma_sq.transform(tfb.Exp())
 
+gb = lsl.GraphBuilder().add(y)
 model = gb.build_model()
 lsl.plot_vars(model)
 ```

--- a/docs/source/tutorials/qmd/01a-transform.qmd
+++ b/docs/source/tutorials/qmd/01a-transform.qmd
@@ -66,7 +66,7 @@ y_dist = lsl.Dist(tfd.Normal, loc=mu, scale=sigma)
 y = lsl.Var(y_vec, distribution=y_dist, name="y")
 ```
 
-Now let's try to sample the full parameter vector $(\boldsymbol{\beta}', \sigma)'$ with a single NUTS kernel instead of using a NUTS kernel for $\boldsymbol{\beta}$ and a Gibbs kernel for $\sigma^2$. Since the standard deviation is a positive-valued parameter, we need to log-transform it to sample it with a NUTS kernel. The {class}`.Var` class provides the {meth}`.Var.transform` method for this purpose.
+Now let's try to sample the full parameter vector $(\boldsymbol{\beta}', \sigma)'$ with a single NUTS kernel instead of using a NUTS kernel for $\boldsymbol{\beta}$ and a Gibbs kernel for $\sigma^2$. Since the standard deviation is a positive-valued parameter, we need to log-transform it to sample it with a NUTS kernel. The {class}`.Var` class provides the method {meth}`.Var.transform` for this purpose.
 
 ```{python}
 #| label: graph-and-transformation

--- a/docs/source/tutorials/qmd/04-mcycle.qmd
+++ b/docs/source/tutorials/qmd/04-mcycle.qmd
@@ -139,7 +139,7 @@ This is the model graph before the transformation:
 lsl.plot_vars(model)
 ```
 
-To transform the smoothing parameters with the {meth}`.Var.transform` method,
+To transform the smoothing parameters with the method {meth}`.Var.transform`,
 we need to retrieve the nodes and vars form the model. This is necessary, because
 while they are part of a model, the inputs and outputs of nodes and vars cannot
 be changed.

--- a/docs/source/tutorials/qmd/04-mcycle.qmd
+++ b/docs/source/tutorials/qmd/04-mcycle.qmd
@@ -129,7 +129,9 @@ ggplot(data.frame(times = mcycle$times, mean = beta0 + f)) +
 
 ## NUTS sampler
 
-As an alternative, we try a NUTS kernel which samples all model parameters (regression coefficients and smoothing parameters) in one block. To do so, we first need to log-transform the smoothing parameters. This is the model graph before the transformation:
+As an alternative, we try using NUTS kernels for all parameters.
+To do so, we first need to log-transform the smoothing parameters.
+This is the model graph before the transformation:
 
 ```{python}
 #| label: untransformed-graph
@@ -137,7 +139,14 @@ As an alternative, we try a NUTS kernel which samples all model parameters (regr
 lsl.plot_vars(model)
 ```
 
-Before transforming the smoothing parameters with the `lsl.transform_parameter()` function, we first need to copy all model nodes. Once this is done, we need to update the output nodes of the smoothing parameters and rebuild the model. There are two additional nodes in the new model graph.
+To transform the smoothing parameters with the {meth}`.Var.transform` method,
+we need to retrieve the nodes and vars form the model. This is necessary, because
+while they are part of a model, the inputs and outputs of nodes and vars cannot
+be changed.
+We retrieve the nodes and vars using {meth}`.Model.pop_nodes_and_vars`,
+which renders the model empty.
+
+After transformation, there are two additional nodes in the new model graph.
 
 ```{python}
 #| label: transformed-graph
@@ -146,10 +155,11 @@ import tensorflow_probability.substrates.jax.bijectors as tfb
 
 nodes, _vars = model.pop_nodes_and_vars()
 
-gb = lsl.GraphBuilder()
-gb.add(_vars["response"])
-_ = gb.transform(_vars["loc_np0_tau2"], tfb.Exp)
-_ = gb.transform(_vars["scale_np0_tau2"], tfb.Exp)
+_vars["loc_np0_tau2"].transform(tfb.Exp())
+_vars["scale_np0_tau2"].transform(tfb.Exp())
+
+gb = lsl.GraphBuilder().add(_vars["response"])
+
 model = gb.build_model()
 lsl.plot_vars(model)
 ```

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import re
+import warnings
 from collections import Counter
 from collections.abc import Iterable
 from copy import deepcopy
@@ -110,7 +111,7 @@ class GraphBuilder:
         GraphBuilder.
     :meth:`.GraphBuilder.build_model` : Method for building a model from the
         GraphBuilder.
-    :meth:`GraphBuilder.transform` : Transforms a variable by adding a new transformed
+    :meth:`.Var.transform` : Transforms a variable by adding a new transformed
         variable as an input. This is useful for variables that are constrained to a
         certain domain, e.g. positive values.
 
@@ -295,7 +296,7 @@ class GraphBuilder:
         --------
         :meth:`.GraphBuilder.build_model` : Method for building a model from the \
             GraphBuilder.
-        :meth:`GraphBuilder.transform` : Transforms a variable by adding a new
+        :meth:`.Var.transform` : Transforms a variable by adding a new
             transformed variable as an input.
 
         Examples
@@ -698,6 +699,10 @@ class GraphBuilder:
         """
         Transforms a variable by adding a new transformed variable as an input.
 
+        .. deprecated:: 0.2.9
+            ``GraphBuilder.transform`` is deprecated.
+            Use :meth:`.Var.transform` instead. This method will be removed in v0.4.0.
+
         Creates a new variable on the unconstrained space ``R**n`` with the appropriate
         transformed distribution, turning the original variable into a weak variable
         without an associated distribution. The transformation is performed using
@@ -763,6 +768,12 @@ class GraphBuilder:
         >>> scale.update().log_prob
         0.0
         """
+
+        warnings.warn(
+            "GraphBuilder.transform is deprecated. Use Var.transform instead. "
+            "This method will be removed in v0.4.0",
+            FutureWarning,
+        )
 
         if var.weak:
             raise RuntimeError(f"{repr(var)} is weak")

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -444,7 +444,13 @@ class GraphBuilder:
 
         for var in _vars:
             if var.auto_transform:
-                gb.transform(var)
+                tname = f"{var.name}_transformed"
+                if tname in nodes or tname in _vars:
+                    raise RuntimeError(
+                        f"Auto-transform of {var} failed, because a variable of the "
+                        f"name {tname} is already present in {gb}."
+                    )
+                var.transform(bijector=None)
 
         gb._set_missing_names()
         gb._add_model_log_lik_node()

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -37,6 +37,7 @@ from .nodes import (
     TransientIdentity,
     Var,
     VarValue,
+    is_bijector_class,
 )
 from .viz import plot_nodes, plot_vars
 
@@ -785,7 +786,7 @@ class GraphBuilder:
         if var.dist_node is None:
             raise RuntimeError(f"{repr(var)} has no distribution")
 
-        if bijector is not None and not isinstance(bijector, type) and (args or kwargs):
+        if not is_bijector_class(bijector) and (args or kwargs):
             raise RuntimeError(
                 "You passed a bijector instance and "
                 "nonempty bijector arguments. You should either initialise your "

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -832,7 +832,7 @@ class GraphBuilder:
             bijector, type
         )
 
-        if isinstance(bijector, type) and not args and not kwargs:
+        if isinstance(bijector, type) and not (args or kwargs):
             warnings.warn(
                 "You passed a bijector class instead of an instance, but did not "
                 "provide any arguments. You should either provide arguments "

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1525,7 +1525,7 @@ def _transform_var_with_bijector_instance(var: Var, bijector_inst: jb.Bijector) 
         transform_dist,
         *inputs,
         **kwinputs,
-        _name=var.dist_node.name,
+        _name="",
         _needs_seed=var.dist_node.needs_seed,
     )
 
@@ -1572,7 +1572,7 @@ def _transform_var_with_bijector_class(
         transform_dist,
         dist_inputs,
         bijector_inputs,
-        _name=var.dist_node.name,
+        _name="",
         _needs_seed=var.dist_node.needs_seed,
     )
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1141,7 +1141,8 @@ class Var:
         ------
         RuntimeError
             If the variable is weak or if the variable has no distribution.
-            Also, if the argument ``bijector`` is ``None``, but the distribution does
+        ValueError
+            If the argument ``bijector`` is ``None``, but the distribution does
             not have a default event space bijector.
 
         Notes
@@ -1220,7 +1221,7 @@ class Var:
             raise RuntimeError(f"{repr(self)} has no distribution")
 
         if isinstance(bijector, type) and not bijector_args and not bijector_kwargs:
-            raise RuntimeError(
+            raise ValueError(
                 "You passed a bijector class instead of an instance, but did not "
                 "provide any arguments for the bijector. You should either provide "
                 "arguments or pass an instance of the bijector class instead."

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -994,6 +994,9 @@ class Var:
 
     See Also
     --------
+    :meth:`.Var.transform` : Transforms a variable by adding a new transformed
+        variable as an input. This is useful for variables that are constrained to a
+        certain domain, e.g. positive values.
     .obs : Helper function to declare a variable as an observed quantity.
     .param : Helper function to declare a variable as a model parameter.
     .Calc :

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1238,21 +1238,17 @@ class Var:
         use_default_bijector = bijector is None
         if use_default_bijector:
             dist_inst = self.dist_node.init_dist()
-            bijector = dist_inst.experimental_default_event_space_bijector
+            default_bijector = dist_inst.experimental_default_event_space_bijector
 
-        if use_default_bijector and bijector is None:
+        if use_default_bijector and default_bijector is None:
             raise RuntimeError(
                 f"{self} has distribution without default event space bijector "
                 "and no bijector was given"
             )
 
-        if is_bijector_class(bijector):
+        if is_bijector_class(bijector) or use_default_bijector:
             tvar = _transform_var_with_bijector_class(
                 self, bijector, *bijector_args, **bijector_kwargs
-            )
-        elif use_default_bijector:
-            tvar = _transform_var_with_bijector_class(
-                self, None, *bijector_args, **bijector_kwargs
             )
         elif isinstance(bijector, jb.Bijector):
             if bijector_args or bijector_kwargs:

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1222,16 +1222,8 @@ class Var:
         if isinstance(bijector, type) and not bijector_args and not bijector_kwargs:
             raise RuntimeError(
                 "You passed a bijector class instead of an instance, but did not "
-                "provide any arguments. You should either provide arguments "
-                "or pass an instance of the bijector class."
-            )
-
-        if not isinstance(bijector, type) and (bijector_args or bijector_kwargs):
-            raise RuntimeError(
-                "You passed a bijector instance and "
-                "nonempty bijector arguments. You should either initialise your "
-                "bijector directly with the arguments, or pass a bijector class "
-                "instead."
+                "provide any arguments for the bijector. You should either provide "
+                "arguments or pass an instance of the bijector class instead."
             )
 
         # avoid infinite recursion
@@ -1248,6 +1240,13 @@ class Var:
                 self, bijector, *bijector_args, **bijector_kwargs
             )
         else:
+            if bijector_args or bijector_kwargs:
+                raise RuntimeError(
+                    "You passed a bijector instance and "
+                    "nonempty bijector arguments. You should either initialise your "
+                    "bijector directly with the arguments, or pass a bijector class "
+                    "instead."
+                )
             tvar = _transform_var_with_bijector_instance(self, bijector)
 
         tvar.parameter = self.parameter  # type: ignore

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1100,6 +1100,126 @@ class Var:
 
         return _unique_tuple(_vars)
 
+    def transform(
+        self,
+        bijector: type[jb.Bijector] | jb.Bijector | None,
+        *bijector_args,
+        **bijector_kwargs,
+    ) -> Var:
+        """
+        Transforms the variable by adding a new transformed variable as an input.
+
+        Creates a new variable on the transformed space the accordingly
+        transformed distribution, turning the original variable into a weak variable
+        without an associated distribution.
+
+        The value of the attribute :attr:`~liesel.model.nodes.Var.parameter` is
+        transferred to the transformed variable and set to ``False`` on the original
+        variable. The attributes :attr:`~liesel.model.nodes.Var.observed` and
+        :attr:`~liesel.model.nodes.Var.role` are set to the default values for
+        the transformed variable and remain unchanged on the original variable.
+
+        Parameters
+        ----------
+        bijector
+            The bijector used to map the new transformed variable to this variable \
+            (forward transformation). If ``None``, the experimental default event \
+            space bijector (see TFP documentation) is used. If a bijector class is \
+            passed, it is instantiated with the arguments ``bijector_args`` and \
+            ``bijector_kwargs``. If a bijector instance is passed, it is used \
+            directly.
+        bijector_args
+            The arguments passed on to the init function of the bijector.
+        bijector_kwargs
+            The keyword arguments passed on to the init function of the bijector.
+
+        Returns
+        -------
+        The new transformed variable which acts as an input to this variable.
+
+        Raises
+        ------
+        RuntimeError
+            If the variable is weak, has no TFP distribution, and if the distribution
+            does not have a default event space bijector and the argument
+            ``bijector`` is ``None``.
+
+        Notes
+        -----
+        Assumes that the distribution of this variable is a distribution from
+        ``tensorflow_probability.subtrates.jax.distributions``.
+
+        Examples
+        --------
+
+        >>> import tensorflow_probability.substrates.jax.distributions as tfd
+        >>> import tensorflow_probability.substrates.jax.bijectors as tfb
+
+        Assume we have a variable ``scale`` that is constrained to be positive, and
+        we want to include the log-transformation of this variable in the model.
+        We first set up the parameter var with its distribution:
+
+        >>> prior = lsl.Dist(tfd.HalfCauchy, loc=0.0, scale=25.0)
+        >>> scale = lsl.param(1.0, prior, name="scale")
+
+        The we transform the variable to the log-scale:
+
+        >>> log_scale = scale.transform(tfb.Exp())
+        >>> log_scale
+        Var(name="scale_transformed")
+
+        Now the ``log_scale`` has a log probability, and the ``scale`` variable does
+        not:
+
+        >>> log_scale.update().log_prob
+        Array(-3.6720574, dtype=float32)
+
+        >>> scale.update().log_prob
+        0.0
+        """
+        if self.weak:
+            raise RuntimeError(f"{repr(self)} is weak")
+
+        if self.dist_node is None:  # type: ignore
+            raise RuntimeError(f"{repr(self)} has no distribution")
+
+        if isinstance(bijector, type) and not bijector_args and not bijector_kwargs:
+            raise RuntimeError(
+                "You passed a bijector class instead of an instance, but did not "
+                "provide any arguments. You should either provide arguments "
+                "or pass an instance of the bijector class."
+            )
+
+        if not isinstance(bijector, type) and (bijector_args or bijector_kwargs):
+            raise RuntimeError(
+                "You passed a bijector instance and "
+                "nonempty bijector arguments. You should either initialise your "
+                "bijector directly with the arguments, or pass a bijector class "
+                "instead."
+            )
+
+        # avoid infinite recursion
+        self.auto_transform = False
+
+        if isinstance(bijector, type):
+            tvar = _transform_var_with_bijector_class(
+                self, bijector, *bijector_args, **bijector_kwargs
+            )
+        elif bijector is None:
+            dist_inst = self.dist_node.init_dist()
+            bijector = dist_inst.experimental_default_event_space_bijector
+            tvar = _transform_var_with_bijector_class(
+                self, bijector, *bijector_args, **bijector_kwargs
+            )
+        else:
+            tvar = _transform_var_with_bijector_instance(self, bijector)
+
+        tvar.parameter = self.parameter  # type: ignore
+        self.parameter = False
+        self.dist_node = None
+
+        return tvar
+
     @in_model_method
     def all_output_nodes(self) -> tuple[Node, ...]:
         """Returns all output *nodes* as a unique tuple."""
@@ -1384,6 +1504,92 @@ class Var:
 
     def __repr__(self) -> str:
         return f'{type(self).__name__}(name="{self.name}")'
+
+
+def _transform_var_with_bijector_instance(var: Var, bijector_inst: jb.Bijector) -> Var:
+    if var.dist_node is None:  # type: ignore
+        raise RuntimeError(f"{var} has no distribution")
+    InputDist = var.dist_node.distribution
+    inputs = var.dist_node.inputs
+    kwinputs = var.dist_node.kwinputs
+
+    bijector_inv = jb.Invert(bijector_inst)
+
+    def transform_dist(*args, **kwargs):
+        return jd.TransformedDistribution(InputDist(*args, **kwargs), bijector_inv)
+
+    transformed_dist = Dist(
+        transform_dist,
+        *inputs,
+        **kwinputs,
+        _name=var.dist_node.name,
+        _needs_seed=var.dist_node.needs_seed,
+    )
+
+    transformed_dist.per_obs = var.dist_node.per_obs
+
+    transformed_var = Var(
+        bijector_inv.forward(var.value),
+        transformed_dist,
+        name=f"{var.name}_transformed",
+    )
+
+    var.value_node = Calc(bijector_inst.forward, transformed_var)
+    return transformed_var
+
+
+def _transform_var_with_bijector_class(
+    var: Var, bijector_cls: type[jb.Bijector], *args, **kwargs
+) -> Var:
+    if var.dist_node is None:  # type: ignore
+        raise RuntimeError(f"{var} has no distribution")
+    InputDist = var.dist_node.distribution
+
+    dist_inputs = InputGroup(
+        *var.dist_node.inputs,
+        **var.dist_node.kwinputs,  # type: ignore
+    )
+
+    bijector_inputs = InputGroup(*args, **kwargs)
+
+    # define distribution "class" for the transformed var
+    def transform_dist(dist_args: ArgGroup, bijector_args: ArgGroup):
+        tfp_dist = InputDist(*dist_args.args, **dist_args.kwargs)
+
+        bijector_inst = bijector_cls(*bijector_args.args, **bijector_args.kwargs)
+        bijector_inv = jb.Invert(bijector_inst)
+
+        transformed_dist = jd.TransformedDistribution(
+            tfp_dist, bijector_inv, validate_args=tfp_dist.validate_args
+        )
+
+        return transformed_dist
+
+    dist_node_transformed = Dist(
+        transform_dist,
+        dist_inputs,
+        bijector_inputs,
+        _name=var.dist_node.name,
+        _needs_seed=var.dist_node.needs_seed,
+    )
+
+    dist_node_transformed.per_obs = var.dist_node.per_obs
+
+    bijector_obj = dist_node_transformed.init_dist().bijector
+
+    transformed_var = Var(
+        bijector_obj.forward(var.value),
+        dist_node_transformed,
+        name=f"{var.name}_transformed",
+    )
+
+    def bijector_fn(value, dist_inputs, bijector_inputs):
+        bijector = transform_dist(dist_inputs, bijector_inputs).bijector
+        return bijector.inverse(value)
+
+    var.value_node = Calc(bijector_fn, transformed_var, dist_inputs, bijector_inputs)
+
+    return transformed_var
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1105,7 +1105,7 @@ class Var:
 
     def transform(
         self,
-        bijector: type[jb.Bijector] | jb.Bijector | None,
+        bijector: type[jb.Bijector] | jb.Bijector | None = None,
         *bijector_args,
         **bijector_kwargs,
     ) -> Var:

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1,5 +1,6 @@
 import tempfile
 import typing
+import warnings
 from collections.abc import Generator
 from itertools import combinations
 from types import MappingProxyType
@@ -342,7 +343,9 @@ class TestModel:
         _, vars = model.copy_nodes_and_vars()
 
         gb.add(*vars.values())
-        gb.transform(vars["x"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", (FutureWarning))
+            gb.transform(vars["x"])
         new_model = gb.build_model()
 
         assert "x_transformed" in new_model.vars

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -550,7 +550,7 @@ class TestVarTransform:
     def test_transform_class_no_args(self) -> None:
         prior = lnodes.Dist(tfp.distributions.HalfCauchy, loc=0.0, scale=25.0)
         tau = lnodes.Var(10.0, prior, name="tau")
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ValueError):
             tau.transform(tfp.bijectors.Exp)
 
     def test_transform_class_with_args(self) -> None:

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 
 import numpy as np
 import pytest
@@ -530,7 +531,9 @@ class TestVarTransform:
 
         prior = lnodes.Dist(tfp.distributions.HalfCauchy, loc=0.0, scale=25.0)
         tau = lnodes.Var(10.0, prior, name="tau")
-        log_tau_gb = lmodel.GraphBuilder().transform(tau, tfp.bijectors.Exp)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", (FutureWarning))
+            log_tau_gb = lmodel.GraphBuilder().transform(tau, tfp.bijectors.Exp())
 
         assert tau.weak
         assert not log_tau.weak
@@ -569,9 +572,11 @@ class TestVarTransform:
 
         prior = lnodes.Dist(tfp.distributions.HalfCauchy, loc=0.0, scale=25.0)
         tau = lnodes.Var(10.0, prior, name="tau")
-        transformed_tau_gb = lmodel.GraphBuilder().transform(
-            tau, tfp.bijectors.Softplus, hinge_softness=lnodes.Var(0.9)
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", (FutureWarning))
+            transformed_tau_gb = lmodel.GraphBuilder().transform(
+                tau, tfp.bijectors.Softplus, hinge_softness=lnodes.Var(0.9)
+            )
 
         assert tau.weak
         assert not transformed_tau.weak
@@ -588,7 +593,7 @@ class TestVarTransform:
     def test_transform_default(self) -> None:
         prior = lnodes.Dist(tfp.distributions.HalfCauchy, loc=0.0, scale=25.0)
         tau = lnodes.Var(10.0, prior, name="tau")
-        log_tau = tau.transform(None)
+        log_tau = tau.transform()
         tau.update()
 
         assert tau.weak
@@ -600,7 +605,9 @@ class TestVarTransform:
 
         prior = lnodes.Dist(tfp.distributions.HalfCauchy, loc=0.0, scale=25.0)
         tau = lnodes.Var(10.0, prior, name="tau")
-        log_tau_gb = lmodel.GraphBuilder().transform(tau)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", (FutureWarning))
+            log_tau_gb = lmodel.GraphBuilder().transform(tau)
 
         assert tau.weak
         assert not log_tau.weak


### PR DESCRIPTION
This PR introduces a `Var.transform` method. Some notes:

### Replacing `GraphBuilder.transform`

We currently have `GraphBuilder.transform`. The new method is in fact intended as a replacement for `GraphBuilder.transform`. Having `Var.transform` as a method on `Var` has the advantage that it is easier to find for users. Since the transformation is "doing something to a Var" and it does not actually require any functionality within the GraphBuilder, living as a method on a Var is a natural development for the transform method.

### Behavior change

The method behaves similar to `GraphBuilder.transform`, with a few notable differences:

1. It will *not* use the default event space bijector from tensorflow by default. This change is made to encourage users to either select their desired bijector manually, which is often sensible, or to request an automatic bijector manually. In both cases, users are more aware of what they are doing.
2. The new method accepts bijector *instances* in addition to bijector *classes*. In fact, passing an instance is the preferred way of passing a bijector. Passing a bijector class is only supported if you actually defined `*bijector_args` or `*bijector_kwargs` to be passed to the bijector. This simplifies the code for the default case. More importantly, this fixes the graph representation after transformation, see below.


Using a bijector instance:

<img width="950" alt="image" src="https://github.com/liesel-devs/liesel/assets/37882800/802ffaf4-fc97-4033-99e0-20dd9619fb42">


Compare to using the default event space bijector. Note that in this case, the same bijector is being used, but there are spurious edges from the nodes "v0" and "v1", the prior parameters, to the original variable "tau".

<img width="940" alt="image" src="https://github.com/liesel-devs/liesel/assets/37882800/7a021ef4-4613-4a6e-aa58-bbc8ce11366b">

### Deprecation and updated documentation

1. I marked `GraphBuilder.transform` as deprecated and included directions towards the new method in its documentation.
2. I updated the usage of the transformation method in the tutorials `01a-transform.md` and `04-mcycle.md`. As it turned out, usage in these tutorials was outdated anyway.

### Notebook for testing

You can play around with the method in this notebook:

[050-transform.ipynb.zip](https://github.com/liesel-devs/liesel/files/13779942/050-transform.ipynb.zip)


### Related issues

- This PR closes #173 
- This PR closes #93
- This PR improves upon the behavior described in #89, because the problem described in #89 does not occur if a bijector instance is passed.