### PR TITLE
Use black preview in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
     rev: 23.10.1
     hooks:
       - id: black
+        args: [--preview]
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:

--- a/liesel/goose/engine.py
+++ b/liesel/goose/engine.py
@@ -642,9 +642,7 @@ class Engine:
         None | KernelStates,
         None | dict[str, GeneratedQuantity],
     ]:
-        def scan_f(
-            carry: Carry, key: KeyArray
-        ) -> tuple[
+        def scan_f(carry: Carry, key: KeyArray) -> tuple[
             Carry,
             tuple[
                 Position,

--- a/liesel/goose/kernel_sequence.py
+++ b/liesel/goose/kernel_sequence.py
@@ -69,7 +69,7 @@ class KernelSequence:
         for ker in kernels:
             if not ker.identifier:
                 raise RuntimeError(
-                    f"Kernel identifier must be a non-empty string. "
+                    "Kernel identifier must be a non-empty string. "
                     f"The field is empty in {ker!r}."
                 )
             identifiers.add(ker.identifier)

--- a/liesel/model/goose.py
+++ b/liesel/model/goose.py
@@ -34,10 +34,8 @@ class GooseModel:
     def __init__(self, model: Model):
         self._model = model._copy_computational_model()
         warnings.warn(
-            (
-                "lsl.GooseModel is deprecated. Use gs.LieselInterface instead."
-                "This alias will be removed in v0.4.0."
-            ),
+            "lsl.GooseModel is deprecated. Use gs.LieselInterface instead."
+            "This alias will be removed in v0.4.0.",
             FutureWarning,
         )
 

--- a/liesel/model/viz.py
+++ b/liesel/model/viz.py
@@ -146,9 +146,11 @@ def _add_labels(graph, axis, pos):
     """Adds labels to the figure."""
 
     labels = {
-        node: f"{type(node).__name__}\n{node.name}"
-        if node.name is not None
-        else node.role.name
+        node: (
+            f"{type(node).__name__}\n{node.name}"
+            if node.name is not None
+            else node.role.name
+        )
         for node in pos
     }
 

--- a/tests/distributions/test_mvn_degen.py
+++ b/tests/distributions/test_mvn_degen.py
@@ -1,6 +1,7 @@
 """
 Tests for the multivariate normal degenerate distribution.
 """
+
 import jax
 import jax.numpy as jnp
 import jax.numpy.linalg as jnpla

--- a/tests/goose/test_builder.py
+++ b/tests/goose/test_builder.py
@@ -33,10 +33,12 @@ def test_jitter_fns():
     builder.set_initial_values(ms, multiple_chains=False)
     builder.set_jitter_fns(
         {
-            "x": lambda key, cv: cv
-            + tfd.Uniform(-1.0, 1.0).sample(sample_shape=cv.shape, seed=key),
-            "y": lambda key, cv: cv
-            + tfd.Uniform(-1.0, 1.0).sample(sample_shape=cv.shape, seed=key),
+            "x": lambda key, cv: cv + tfd.Uniform(-1.0, 1.0).sample(
+                sample_shape=cv.shape, seed=key
+            ),
+            "y": lambda key, cv: cv + tfd.Uniform(-1.0, 1.0).sample(
+                sample_shape=cv.shape, seed=key
+            ),
         }
     )
     builder.add_kernel(gs.IWLSKernel(["x", "y"]))


### PR DESCRIPTION
This PR simply adds the line `args: [--preview]` to the black configuration for our pre-commit. I think this is nice predominantly because this includes automatic formatting of long strings, which can be quite annoying. But there's another nice stuff, too, see here: https://black.readthedocs.io/en/stable/the_black_code_style/future_style.html For example, dictionary and list formatting was also improved.