### PR TITLE
Turn off update_on_init for special model nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.10] - [unreleased]
 
+- :construction: Fixed spurious warning during model creation (#186, @jobrachem)
 
 ## [0.2.9] - 2024-04-04
 

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -167,7 +167,7 @@ class GraphBuilder:
 
         _, _vars = self._all_nodes_and_vars()
         inputs = (v.dist_node for v in _vars if v.has_dist and v.observed)
-        node = Calc(_reduced_sum, *inputs, _name="_model_log_lik")
+        node = Calc(_reduced_sum, *inputs, _name="_model_log_lik", update_on_init=False)
         self.add(node)
         return self
 
@@ -180,7 +180,9 @@ class GraphBuilder:
 
         _, _vars = self._all_nodes_and_vars()
         inputs = (v.dist_node for v in _vars if v.has_dist and v.parameter)
-        node = Calc(_reduced_sum, *inputs, _name="_model_log_prior")
+        node = Calc(
+            _reduced_sum, *inputs, _name="_model_log_prior", update_on_init=False
+        )
         self.add(node)
         return self
 
@@ -193,7 +195,9 @@ class GraphBuilder:
 
         nodes, _ = self._all_nodes_and_vars()
         inputs = (n for n in nodes if isinstance(n, Dist))
-        node = Calc(_reduced_sum, *inputs, _name="_model_log_prob")
+        node = Calc(
+            _reduced_sum, *inputs, _name="_model_log_prob", update_on_init=False
+        )
         self.add(node)
         return self
 


### PR DESCRIPTION
The adoption of #92 caused warnings to be logged by default during model initialization, because the special nodes for the log likelihood and log probability cannot always be updated directly on their initialization. This PR just sets `update_on_init=False` for these nodes, which solves the issue.