### PR TITLE
Update logging setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.10] - [unreleased]
 
+- :construction: Update logging setup (#187, @jobrachem)
 
 ## [0.2.9] - 2024-04-04
 

--- a/liesel/logging.py
+++ b/liesel/logging.py
@@ -26,7 +26,7 @@ def setup_logger() -> None:
     # This is the level that will in principle be handled by the logger.
     # If it is set, for example, to logging.WARNING, this logger will never
     # emit messages of a level below warning
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
 
     # By setting this to False, we prevent the Liesel log messages from being passed on
     # to the root logger. This prevents duplication of the log messages
@@ -34,7 +34,6 @@ def setup_logger() -> None:
 
     # This is the default handler that we set for our log messages
     handler = logging.StreamHandler()
-    handler.setLevel(logging.INFO)
 
     # We define the format of log messages for this handler
     formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")


### PR DESCRIPTION
Small update to make the liesel default logger behave more like you would expect.

- Increased the level of the `"liesel"` logger from `DEBUG` to `INFO`
- Removed the level `INFO` from the default handler for the liesel logger.


Now, you can simply update the logging level like this:

```python
import logging

logger = logging.getLogger("liesel")
logger.setLevel(logging.DEBUG)
```

Before, our setup required that you changed the level on the *handler*, which is less obvious:

```python
import logging

logger = logging.getLogger("liesel")
logger.handlers[0].setLevel(logging.DEBUG)
```