### PR TITLE
Unpin scipy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     networkx>=2.6
     numpy>=1.22,!=1.24.0
     pandas>=1.4
-    scipy>=1.8, <=1.12.0
+    scipy>=1.8.0
     seaborn>=0.13
     tensorflow-probability>=0.17
     tqdm>=4.62

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     jaxlib>=0.4.1
     matplotlib>=3.5
     networkx>=2.6
-    numpy>=1.22,!=1.24.0
+    numpy>=1.22,!=1.24.0,<2.0
     pandas>=1.4
     scipy>=1.8.0
     seaborn>=0.13


### PR DESCRIPTION
Cannot reproduce the issue reported in #185, so this PR simply removes the pin to scipy<=1.12.
Closes #185 

Opened as a draft to see if our CI passes.