### PR TITLE
Var constructors: new_param, new_obs, new_calc, new_value

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import tensorflow_probability.substrates.jax.distributions as tfd
 
 import liesel.goose as gs
 import liesel.model as lsl
@@ -19,3 +20,4 @@ def add_doctest_imports(doctest_namespace):
     doctest_namespace["jnp"] = jnp
     doctest_namespace["gs"] = gs
     doctest_namespace["lsl"] = lsl
+    doctest_namespace["tfd"] = tfd

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -10,11 +10,16 @@ We usually import ``liesel.model`` as follows::
 
     import liesel.model as lsl
 
+Additionnaly, it often makes sense to import ``jax.numpy`` and tensorflow probability::
+
+    import jax.numpy as jnp
+    import tensorflow_probability.substrates.jax.distributions as tfd
+
 
 The model building workflow in Liesel consists of two steps:
 
 1. Set up the nodes and variables that make up your model.
-2. Set up a :class:`.GraphBuilder`, add your root node(s) to it, and call :meth:`.GraphBuilder.build_model` to build your model graph.
+2. Initialize a :class:`.Model` with your root variable(s).
 
 .. note::
     This document provides an overview of the most important classes for model building.
@@ -22,12 +27,11 @@ The model building workflow in Liesel consists of two steps:
     and in the :doc:`tutorials <tutorials_overview>`.
 
 
-Nodes and Variables
--------------------
+Variables: The model building blocks
+------------------------------------
 
-The fundamental building blocks of your model graph are given by just four classes.
-Each of these building blocks is documented with examples, so make
-sure to check them out.
+The fundamental building blocks of your model graph are given by just two classes.
+Both are documented with examples, so make sure to check them out.
 
 .. autosummary::
     :toctree: generated
@@ -35,21 +39,22 @@ sure to check them out.
     :nosignatures:
 
     ~liesel.model.nodes.Var
-    ~liesel.model.nodes.Value
-    ~liesel.model.nodes.Calc
     ~liesel.model.nodes.Dist
 
-To set up :class:`.Var` objects, Liesel provides two helper functions:
+To set up :class:`.Var` objects, Liesel provides four constructors:
 
 .. autosummary::
     :toctree: generated
     :recursive:
     :nosignatures:
 
-    ~liesel.model.nodes.obs
-    ~liesel.model.nodes.param
+    ~liesel.model.nodes.Var.new_param
+    ~liesel.model.nodes.Var.new_obs
+    ~liesel.model.nodes.Var.new_calc
+    ~liesel.model.nodes.Var.new_value
 
-Defining :class:`.Var` objects with these functions makes sure that the respective
+We recommend to always use one of these constructors when initializing a variable.
+This makes sure that the respective
 :attr:`.Var.observerd` and :attr:`.Var.parameter` flags are correctly set. This in
 turn ensures that the :attr:`.Var.log_prob` of an *observed* variable will be included
 in the :attr:`.Model.log_lik` and the :attr:`.Var.log_prob` of a *parameter* variable
@@ -59,7 +64,17 @@ will be included in the :attr:`.Model.log_prior`.
 Build and plot your model
 -------------------------
 
-The most important class here is the :class:`.GraphBuilder`.
+The most important class here is the :class:`.Model`.
+
+.. autosummary::
+    :toctree: generated
+    :recursive:
+    :nosignatures:
+
+    ~liesel.model.model.Model
+    ~liesel.model.viz.plot_vars
+
+For advanced users, further interesting functionality can be found here:
 
 .. autosummary::
     :toctree: generated
@@ -67,6 +82,4 @@ The most important class here is the :class:`.GraphBuilder`.
     :nosignatures:
 
     ~liesel.model.model.GraphBuilder
-    ~liesel.model.model.Model
-    ~liesel.model.viz.plot_vars
     ~liesel.model.viz.plot_nodes

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -55,7 +55,7 @@ To set up :class:`.Var` objects, Liesel provides four constructors:
 
 We recommend to always use one of these constructors when initializing a variable.
 This makes sure that the respective
-:attr:`.Var.observerd` and :attr:`.Var.parameter` flags are correctly set. This in
+:attr:`.Var.observed` and :attr:`.Var.parameter` flags are correctly set. This in
 turn ensures that the :attr:`.Var.log_prob` of an *observed* variable will be included
 in the :attr:`.Model.log_lik` and the :attr:`.Var.log_prob` of a *parameter* variable
 will be included in the :attr:`.Model.log_prior`.

--- a/docs/source/welcome.md
+++ b/docs/source/welcome.md
@@ -28,11 +28,20 @@ $ pip install liesel
 If you want to work with the latest development version of Liesel or use PyGraphviz for
 prettier plots of the model graphs, see the [README][5] in the main repository.
 
-Now you can get started. We recommend using the following import paths:
+Now you can get started. Throughout this documentation, we import Liesel as follows:
 
 ```python
 import liesel.model as lsl
 import liesel.goose as gs
+```
+
+We also commonly use the following imports:
+
+```python
+import jax
+import jax.numpy as jnp
+import numpy as np
+import tensorflow_probability.substrates.jax.distributions as tfd
 ```
 
 We provide overviews of the most important building blocks provided by `liesel.model`

--- a/liesel/goose/optim.py
+++ b/liesel/goose/optim.py
@@ -330,7 +330,8 @@ def optim_flat(
 
     Now, we are ready to run the optimization.
 
-    >>> result = gs.optim_flat(model, params=["coef"])
+    >>> stopper = gs.Stopper(max_iter=1000, patience=10, atol=0.01)
+    >>> result = gs.optim_flat(model, params=["coef"], stopper=stopper)
     >>> {name: jnp.round(value, 2) for name, value in result.position.items()}
     {'coef': Array([0.52, 1.29], dtype=float32)}
 

--- a/liesel/model/legacy.py
+++ b/liesel/model/legacy.py
@@ -210,7 +210,8 @@ def Obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
     :func:`.obs` : New alias. Sould be used in future code.
     """
     warnings.warn(
-        "Use lsl.obs() instead. This alias will be removed in v0.4.0", FutureWarning
+        "Use lsl.Var.new_obs() instead. This class will be removed in v0.4.0",
+        FutureWarning,
     )
     return obs(value, distribution, name)
 
@@ -238,6 +239,7 @@ def Param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
     :func:`.param` : New alias. Sould be used in future code.
     """
     warnings.warn(
-        "Use lsl.param() instead. This alias will be removed in v0.4.0", FutureWarning
+        "Use lsl.Var.new_param() instead. This class will be removed in v0.4.0",
+        FutureWarning,
     )
     return param(value, distribution, name)

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -969,7 +969,8 @@ class Model:
         distribution of a variable or the inputs of a calculation. Afterwards, you
         initialize a *new* model with your changed variables.
         If you simply want to change the value of a variable, it is not necessary to
-        call :meth:`~.Model.pop_nodes_and_vars`.
+        call :meth:`~.Model.pop_nodes_and_vars`, you can simply override the
+        :attr:`.Var.value` attribute. Remeber to call :meth:`.Model.update` afterwards.
 
     Parameters
     ----------

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -12,7 +12,7 @@ from collections.abc import Callable, Hashable, Iterable
 from functools import wraps
 from itertools import chain
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, NamedTuple, Self, TypeVar, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, Union
 
 import tensorflow_probability.substrates.jax.bijectors as jb
 import tensorflow_probability.substrates.jax.distributions as jd
@@ -1073,7 +1073,7 @@ class Var:
     @classmethod
     def new_param(
         cls, value: Any, distribution: Dist | None = None, name: str = ""
-    ) -> Self:
+    ) -> Var:
         var = cls(value, distribution, name)
         var.value_node.monitor = True
         var.parameter = True
@@ -1082,7 +1082,7 @@ class Var:
     @classmethod
     def new_obs(
         cls, value: Any, distribution: Dist | None = None, name: str = ""
-    ) -> Self:
+    ) -> Var:
         var = cls(value, distribution, name)
         var.observed = True
         return var
@@ -1096,7 +1096,7 @@ class Var:
         _needs_seed: bool = False,
         update_on_init: bool = True,
         **kwinputs: Any,
-    ) -> Self:
+    ) -> Var:
         calc = Calc(
             function,
             *inputs,
@@ -1109,7 +1109,7 @@ class Var:
         return var
 
     @classmethod
-    def new_const(cls, value: Any, name: str = "") -> Self:
+    def new_const(cls, value: Any, name: str = "") -> Var:
         var = cls(value, name=name)
         return var
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1214,7 +1214,7 @@ class Var:
         >>> def compute_variance(x):
         ...     return jnp.exp(x)**2
         >>> log_scale = lsl.Var.new_param(0.0, name="log_scale")
-        >>> variance = lsl.Car.new_calc(compute_variance, log_scale, name="scale")
+        >>> variance = lsl.Var.new_calc(compute_variance, log_scale, name="scale")
         >>> print(variance.value)
         1.0
 
@@ -1229,7 +1229,7 @@ class Var:
         >>> print(scale.value)
         1.0
         >>> print(scale.update().value)
-        >>> 2.718281828459045
+        2.7182817
 
         .. _docs: https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html # noqa
         """

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -956,16 +956,16 @@ class NoDist(Dist):
 
 class Var:
     """
-    A variable in a statistical model, typically with a probability distribution.
+    A variable in a statistical model.
 
     A variable in Liesel is often a random variable, e.g. an observed or
-    latent variable with a probability distribution, or a model parameter with
-    a prior distribution.
+    latent variable with a probability distribution (see :meth:`~.Var.new_obs`),
+    or a model parameter with a prior distribution (see :meth:`~.Var.new_param`).
 
     Other quantities can also be declared as variables, e.g. fixed data like
-    hyperparameters or design matrices, or quantities that are computed from
-    other nodes, e.g. structured additive predictors in semi-parametric
-    regression models.
+    hyperparameters or design matrices (see :meth:`~.Var.new_value`),
+    or quantities that are computed from other nodes, e.g. structured additive
+    predictors in semi-parametric regression models (see :meth:`~.Var.new_calc`).
 
     .. tip::
         You should initialize variables through one of the four constructors:

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1070,6 +1070,49 @@ class Var:
         self.info: dict[str, Any] = {}
         """Additional meta-information about the variable as a dict."""
 
+    @classmethod
+    def new_param(
+        cls, value: Any, distribution: Dist | None = None, name: str = ""
+    ) -> Var:
+        var = cls(value, distribution, name)
+        var.value_node.monitor = True
+        var.parameter = True
+        return var
+
+    @classmethod
+    def new_obs(
+        cls, value: Any, distribution: Dist | None = None, name: str = ""
+    ) -> Var:
+        var = cls(value, distribution, name)
+        var.observed = True
+        return var
+
+    @classmethod
+    def new_calc(
+        cls,
+        function: Callable[..., Any],
+        *inputs: Any,
+        name: str = "",
+        _needs_seed: bool = False,
+        update_on_init: bool = True,
+        **kwinputs: Any,
+    ) -> Var:
+        calc = Calc(
+            function,
+            *inputs,
+            _name=f"{name}_calc",
+            _needs_seed=_needs_seed,
+            update_on_init=update_on_init,
+            **kwinputs,
+        )
+        var = cls(calc, name=name)
+        return var
+
+    @classmethod
+    def new_const(cls, value: Any, name: str = "") -> Var:
+        var = cls(value, name=name)
+        return var
+
     def all_input_nodes(self) -> tuple[Node, ...]:
         """Returns all input *nodes* as a unique tuple."""
         inputs1 = self.value_node.all_input_nodes()

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -12,7 +12,7 @@ from collections.abc import Callable, Hashable, Iterable
 from functools import wraps
 from itertools import chain
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Self, TypeVar, Union
 
 import tensorflow_probability.substrates.jax.bijectors as jb
 import tensorflow_probability.substrates.jax.distributions as jd
@@ -1073,7 +1073,7 @@ class Var:
     @classmethod
     def new_param(
         cls, value: Any, distribution: Dist | None = None, name: str = ""
-    ) -> Var:
+    ) -> Self:
         var = cls(value, distribution, name)
         var.value_node.monitor = True
         var.parameter = True
@@ -1082,7 +1082,7 @@ class Var:
     @classmethod
     def new_obs(
         cls, value: Any, distribution: Dist | None = None, name: str = ""
-    ) -> Var:
+    ) -> Self:
         var = cls(value, distribution, name)
         var.observed = True
         return var
@@ -1096,7 +1096,7 @@ class Var:
         _needs_seed: bool = False,
         update_on_init: bool = True,
         **kwinputs: Any,
-    ) -> Var:
+    ) -> Self:
         calc = Calc(
             function,
             *inputs,
@@ -1109,7 +1109,7 @@ class Var:
         return var
 
     @classmethod
-    def new_const(cls, value: Any, name: str = "") -> Var:
+    def new_const(cls, value: Any, name: str = "") -> Self:
         var = cls(value, name=name)
         return var
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -611,12 +611,12 @@ class Calc(Node):
 
     See Also
     --------
+    .Var.new_calc :
+        Initializes a weak variable that is a function of other variables.
     .Var : A variable in a statistical model, typically with a probability
         distribution.
     .Var.new_param : Initializes a strong variable that acts as a model parameter.
-    .Var.new_param : Initializes a strong variable that acts as a model parameter.
-    .Var.new_calc :
-        Initializes a weak variable that is a function of other variables.
+    .Var.new_obs : Initializes a strong variable that holds observed data.
     .Var.new_value : Initializes a strong variable without a distribution.
     .Value :
         A node representing some static data.
@@ -983,7 +983,7 @@ class Var:
 
     See Also
     --------
-    .Var.new_param : Initializes a strong variable that acts as a model parameter.
+    .Var.new_obs : Initializes a strong variable that holds observed data.
     .Var.new_param : Initializes a strong variable that acts as a model parameter.
     .Var.new_calc :
         Initializes a weak variable that is a function of other variables.
@@ -1604,6 +1604,9 @@ def obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
     """
     Helper function that returns an observed :class:`.Var`.
 
+    .. deprecated:: v0.2.10
+        Use :meth:`.Var.new_obs` instead. This function will be removed in v0.4.0.
+
     Sets the :attr:`.Var.observed` flag. If the observed variable is a random variable,
     i.e. if it has an associated probability distribution, its log-probability is
     automatically added to the model log-likelihood (see :attr:`.Model.log_lik`).
@@ -1625,17 +1628,7 @@ def obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
 
     See Also
     --------
-    .Calc :
-        A node representing a general calculation/operation in JAX or Python.
-    .Value :
-        A node representing some static data.
-    .Dist :
-        A node representing a ``tensorflow_probability``
-        :class:`~tfp.distributions.Distribution`.
-    .Var : A variable in a statistical model, typically with a probability
-        distribution.
-    .param :
-        A helper function to initialize a :class:`.Var` as a model parameter.
+    .Var.new_obs : Initializes a strong variable that holds observed data.
 
     Notes
     -----
@@ -1673,6 +1666,10 @@ def obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
     Array(-3.0068154, dtype=float32)
 
     """
+    warnings.warn(
+        "Use lsl.Var.new_obs() instead. This function will be removed in v0.4.0",
+        FutureWarning,
+    )
     var = Var(value, distribution, name)
     var.observed = True
     return var
@@ -1681,6 +1678,9 @@ def obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
 def param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> Var:
     """
     Helper function that returns a parameter :class:`.Var`.
+
+    .. deprecated:: v0.2.10
+        Use :meth:`.Var.new_param` instead. This function will be removed in v0.4.0.
 
     Sets the :attr:`.Var.parameter` flag. If the parameter variable is a
     random variable, i.e. if it has an associated probability distribution,
@@ -1703,18 +1703,7 @@ def param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
 
     See Also
     --------
-    .Calc :
-        A node representing a general calculation/operation
-        in JAX or Python.
-    .Value :
-        A node representing some static data.
-    .Dist :
-        A node representing a ``tensorflow_probability``
-        :class:`~tfp.distributions.Distribution`.
-    .Var : A variable in a statistical model, typically with a probability
-        distribution.
-    .obs :
-        A helper function to initialize a :class:`.Var` as an observed variable.
+    .Var.new_param : Initializes a strong variable that acts as a model parameter.
 
     Notes
     -----
@@ -1767,6 +1756,10 @@ def param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
     Array(-3.0068154, dtype=float32)
 
     """
+    warnings.warn(
+        "Use lsl.Var.new_param() instead. This function will be removed in v0.4.0",
+        FutureWarning,
+    )
     var = Var(value, distribution, name)
     var.value_node.monitor = True
     var.parameter = True

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1109,7 +1109,7 @@ class Var:
         return var
 
     @classmethod
-    def new_const(cls, value: Any, name: str = "") -> Var:
+    def new_value(cls, value: Any, name: str = "") -> Var:
         var = cls(value, name=name)
         return var
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1084,43 +1084,44 @@ class Var:
 
     Access keyword inputs to a calculator :attr:`.Var.value_node`:
 
-    >>> a = lsl.Var(2.0, name="a")
-    >>> b = lsl.Var(lsl.Calc(lambda x: x + 1.0, x=a))
+    >>> a = lsl.Var.new_value(2.0, name="a")
+    >>> b = lsl.Var.new_calc(lambda x: x + 1.0, x=a)
     >>> b.value_node["x"]
     Var(name="a")
 
     Access positional inputs to a calculator :attr:`.Var.value_node`:
 
-    >>> a = lsl.Var(2.0, name="a")
-    >>> b = lsl.Var(lsl.Calc(lambda x: x + 1.0, a))
+    >>> a = lsl.Var.new_value(2.0, name="a")
+    >>> b = lsl.Var.new_calc(lambda x: x + 1.0, a)
     >>> b.value_node[0]
     Var(name="a")
 
     Access keyword inputs to a distribution :attr:`.Var.dist_node`:
 
-    >>> a = lsl.Var(2.0, name="a")
-    >>> b = lsl.Var(1.0, lsl.Dist(tfd.Normal, loc=a, scale=1.0))
+    >>> a = lsl.Var.new_value(2.0, name="a")
+    >>> b = lsl.Var.new_obs(1.0, lsl.Dist(tfd.Normal, loc=a, scale=1.0))
     >>> b.dist_node["loc"]
     Var(name="a")
 
     Access positional inputs to a distribution :attr:`.Var.dist_node`:
 
-    >>> a = lsl.Var(2.0, name="a")
-    >>> b = lsl.Var(1.0, lsl.Dist(tfd.Normal, a, scale=1.0))
+    >>> a = lsl.Var.new_value(2.0, name="a")
+    >>> b = lsl.Var.new_obs(1.0, lsl.Dist(tfd.Normal, a, scale=1.0))
     >>> b.dist_node[0]
     Var(name="a")
 
     .. info::
-        Note that, for accessing keyword arguments, you do *not* use :attr:`.Var.name`
+        Note that, for accessing keyword arguments, you do *not* use the
+        :attr:`.Var.name`
         attribute of the looked-for input variable or node, but the *argument name*.
         Consider this case from above::
 
-            a = lsl.Var(2.0, name="a")
-            b = lsl.Var(1.0, lsl.Dist(tfd.Normal, loc=a, scale=1.0))
+            a = lsl.Var.new_value(2.0, name="a")
+            b = lsl.Var.new_obs(1.0, lsl.Dist(tfd.Normal, loc=a, scale=1.0))
             b.dist_node["loc"]
 
         Here, we retrieve the variable ``a`` with the name ``"a"``. But for the
-        indexing, we use the *argument name` ``"loc"`` from the call to ``lsl.Dist`.
+        indexing, we use the *argument name* ``"loc"`` from the call to ``lsl.Dist`.
 
     .. rubric:: Swapping out inputs
 
@@ -1130,18 +1131,18 @@ class Var:
 
     Swap out inputs to a calculator via :attr:`.Var.value_node`:
 
-    >>> a = lsl.Var(2.0, name="a")
-    >>> b = lsl.Var(lsl.Calc(lambda x: x + 1.0, x=a))
-    >>> c = lsl.Var(3.0, name="c")
+    >>> a = lsl.Var.new_value(2.0, name="a")
+    >>> b = lsl.Var.new_calc(lambda x: x + 1.0, x=a)
+    >>> c = lsl.Var.new_value(3.0, name="c")
     >>> b.value_node["x"] = c
     >>> b.value_node["x"]
     Var(name="c")
 
     Swap out inputs to a distribution via :attr:`.Var.dist_node`:
 
-    >>> a = lsl.Var(2.0, name="a")
-    >>> b = lsl.Var(1.0, lsl.Dist(tfd.Normal, loc=a, scale=1.0))
-    >>> c = lsl.Var(3.0, name="c")
+    >>> a = lsl.Var.new_value(2.0, name="a")
+    >>> b = lsl.Var.new_obs(1.0, lsl.Dist(tfd.Normal, loc=a, scale=1.0))
+    >>> c = lsl.Var.new_value(3.0, name="c")
     >>> b.dist_node["loc"] = c
     >>> b.dist_node["loc"]
     Var(name="c")

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -659,4 +659,3 @@ class TestVarTransform:
         log_tau.dist_node.update()  # type: ignore
         log_tau_gb.dist_node.update()  # type: ignore
         assert log_tau.log_prob == pytest.approx(log_tau_gb.log_prob)
-

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -547,6 +547,6 @@ class TestVarConstructors:
         assert loc.weak
 
     def test_new_const(self):
-        loc = lnodes.Var.new_const(1.0, name="loc")
+        loc = lnodes.Var.new_value(1.0, name="loc")
         assert isinstance(loc, lnodes.Var)
         assert loc.strong

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -511,3 +511,42 @@ def test_indirect_connection() -> None:
     assert len(v3.all_input_vars()) == 1
     assert len(v2.all_input_vars()) == 1
     assert len(v0.all_input_vars()) == 0
+
+
+class TestVarConstructors:
+    def test_new_param(self):
+        loc = lnodes.Var.new_param(1.0, name="loc")
+        assert isinstance(loc, lnodes.Var)
+        assert loc.parameter
+        assert loc.value_node.monitor
+        assert loc.strong
+
+        dist = lnodes.Dist(tfp.distributions.Normal, 0.0, 1.0)
+        loc = lnodes.Var.new_param(1.0, dist, name="loc")
+        assert isinstance(loc, lnodes.Var)
+        assert loc.parameter
+        assert loc.value_node.monitor
+        assert loc.strong
+
+    def test_new_obs(self):
+        loc = lnodes.Var.new_obs(1.0, name="loc")
+        assert isinstance(loc, lnodes.Var)
+        assert loc.observed
+        assert loc.strong
+
+        dist = lnodes.Dist(tfp.distributions.Normal, 0.0, 1.0)
+        loc = lnodes.Var.new_obs(1.0, dist, name="loc")
+        assert isinstance(loc, lnodes.Var)
+        assert loc.observed
+        assert loc.strong
+
+    def test_new_calc(self):
+        loc = lnodes.Var.new_calc(lambda x: x + 1.0, 1.0, name="loc")
+        assert isinstance(loc, lnodes.Var)
+        assert loc.value == pytest.approx(2.0)
+        assert loc.weak
+
+    def test_new_const(self):
+        loc = lnodes.Var.new_const(1.0, name="loc")
+        assert isinstance(loc, lnodes.Var)
+        assert loc.strong


### PR DESCRIPTION
For a while now, I have been a little unsatisfied with two things:

1. Incsonsistent UI: `Var` class vs. `param` and `obs` functions. See also #130 
2. The status of the `Data` (or, in #170 : `Value`) node vs. `Var`: Which should you use?

I think there is a satisfying solution:

1. Implement constructors for `Var` that fullfill the tasks above. 
2. Guide users to towards using `Var.new_<constructor>` as a default.

If I recall correctly, using constructors has been proposed before by @wiep.

This PR implements four constructors. 

### Var.new_param

Supersedes `lsl.param()`

```python
class Var:

    @classmethod
    def new_param(
        cls, value: Any, distribution: Dist | None = None, name: str = ""
    ) -> Self:
        ...
```

### Var.new_obs

Supersedes `lsl.obs()`

```python
class Var:
    @classmethod
    def new_obs(
        cls, value: Any, distribution: Dist | None = None, name: str = ""
    ) -> Self:
        ...
```

### Var.new_calc

New. Having this constructor available makes the interface more consistent. Users can simply start typing `Var.new_` and see the available options via auto-completion. It also reduces errors from confusion about nesting `Calc` objects in `Var` constructors.

```python
class Var:
    @classmethod
    def new_calc(
        cls,
        function: Callable[..., Any],
        *inputs: Any,
        name: str = "",
        _needs_seed: bool = False,
        update_on_init: bool = True,
        **kwinputs: Any,
    ) -> Self:
        ...
```

### Var.new_const

New. Like with `Var.new_calc`, having this constructor makes the interface more consistent and supports a good habit.

```python
class Var:
    @classmethod
    def new_const(cls, value: Any, name: str = "") -> Self:
        ...
```


## Todo

This is a draft PR for a first discussion. Even if it remains unchanged, documentation has to be added if it ends up being merged.

- [x] Add documentation
- [x] Add deprecation warnings to `param` and `obs`
- [ ] (Maybe) add a warning to using the default `Var` constructor