### PR TITLE
Enable progress bar in Jupyter notebooks

### DIFF
--- a/liesel/goose/builder.py
+++ b/liesel/goose/builder.py
@@ -152,7 +152,7 @@ class EngineBuilder:
         self.store_kernel_states: bool = False
         self.minimize_transition_infos: bool = False
         self.show_progress: bool = True
-        """Whether to show progress bars curing sampling."""
+        """Whether to show progress bars during sampling."""
 
         self.positions_included: list[str] = []
         """

--- a/liesel/goose/engine.py
+++ b/liesel/goose/engine.py
@@ -712,7 +712,7 @@ class Engine:
         it = range(duration // self._jitted_sample_duration)
 
         if self._show_progress:
-            it = tqdm(it, ncols=80, disable=None, unit="chunk")
+            it = tqdm(it, ncols=80, unit="chunk")
 
         for dur_i in it:
             # FIXME: split for entire duration instead of each loop iteration


### PR DESCRIPTION
Currently, we use `tqdm(disable=None, ...)` for the sampling progress bar:

> It disables the progress bar in non-TTY environments. A TTY (teletypewriter) refers to environments like a terminal or console that supports interactive input/output. In non-TTY environments (e.g., file redirection or certain automated scripts), the progress bar is disabled.

Unfortunately, this has the effect of disabling the progress bar in Jupyter notebooks. This PR removes this argument.

If progress bar printing should be disabled, for example because you are running code on a server and logging output to a file, users can use the existing setting `EngineBuilder.show_progress = False`.


This notebook can be used to see the effect:
[test_sampling.ipynb.zip](https://github.com/user-attachments/files/16787026/test_sampling.ipynb.zip)
