### PR TITLE
Fixes issue with custom log prob in liesel models

### DIFF
--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -33,7 +33,6 @@ from .nodes import (
     InputGroup,
     Node,
     NodeState,
-    TransientIdentity,
     Value,
     Var,
     VarValue,
@@ -171,7 +170,14 @@ class GraphBuilder:
         """Adds the model log-likelihood node with the name ``_model_log_lik``."""
 
         if self.log_lik_node:
-            self.add(TransientIdentity(self.log_lik_node, _name="_model_log_lik"))
+            self.add(
+                Calc(
+                    lambda x: x,
+                    self.log_lik_node,
+                    _name="_model_log_lik",
+                    update_on_init=False,
+                )
+            )
             return self
 
         _, _vars = self._all_nodes_and_vars()
@@ -184,7 +190,14 @@ class GraphBuilder:
         """Adds the model log-prior node with the name ``_model_log_prior``."""
 
         if self.log_prior_node:
-            self.add(TransientIdentity(self.log_prior_node, _name="_model_log_prior"))
+            self.add(
+                Calc(
+                    lambda x: x,
+                    self.log_prior_node,
+                    _name="_model_log_prior",
+                    update_on_init=False,
+                )
+            )
             return self
 
         _, _vars = self._all_nodes_and_vars()
@@ -199,7 +212,14 @@ class GraphBuilder:
         """Adds the model log-probability node with the name ``_model_log_prob``."""
 
         if self.log_prob_node:
-            self.add(TransientIdentity(self.log_prob_node, _name="_model_log_prob"))
+            self.add(
+                Calc(
+                    lambda x: x,
+                    self.log_prob_node,
+                    _name="_model_log_prob",
+                    update_on_init=False,
+                )
+            )
             return self
 
         nodes, _ = self._all_nodes_and_vars()

--- a/tests/model/test_custom_log_prob.py
+++ b/tests/model/test_custom_log_prob.py
@@ -1,0 +1,78 @@
+import jax.numpy as jnp
+import tensorflow_probability.substrates.jax as tfp
+
+import liesel.goose as gs
+import liesel.model as lsl
+
+
+def test_custom_log_prob():
+    node = lsl.Var.new_param(0.0, lsl.Dist(tfp.distributions.Normal, 0.0, 1.0), "node")
+    log_prob_node = lsl.Calc(lambda lp: lp + 1.0, node.dist_node)
+    mb = lsl.GraphBuilder()
+    mb.add(node)
+    mb.log_prob_node = log_prob_node
+
+    model = mb.build_model()
+
+    state = model.state
+    interface = gs.LieselInterface(model)
+
+    updated_state = interface.update_state(gs.Position({"node": 1.0}), state)
+
+    model_log_probs = jnp.array(
+        [interface.log_prob(state), interface.log_prob(updated_state)]
+    )
+
+    log_probs = tfp.distributions.Normal(0.0, 1.0).log_prob(jnp.array([0.0, 1.0])) + 1.0
+
+    assert jnp.allclose(model_log_probs, log_probs)
+
+
+def test_custom_log_prior():
+    node = lsl.Var.new_param(0.0, lsl.Dist(tfp.distributions.Normal, 0.0, 1.0), "node")
+    log_prob_node = lsl.Calc(lambda lp: lp + 1.0, node.dist_node)
+    mb = lsl.GraphBuilder()
+    mb.add(node)
+    mb.log_prior_node = log_prob_node
+
+    model = mb.build_model()
+
+    state = model.state
+    interface = gs.LieselInterface(model)
+
+    updated_state = interface.update_state(gs.Position({"node": 1.0}), state)
+
+    # interface does not give access to prior, so it is directly accessed using the
+    # reserved node name
+    model_log_priors = jnp.array(
+        [state["_model_log_prior"].value, updated_state["_model_log_prior"].value]
+    )
+
+    log_probs = tfp.distributions.Normal(0.0, 1.0).log_prob(jnp.array([0.0, 1.0])) + 1.0
+
+    assert jnp.allclose(model_log_priors, log_probs)
+
+
+def test_custom_log_likelihood():
+    node = lsl.Var.new_param(0.0, lsl.Dist(tfp.distributions.Normal, 0.0, 1.0), "node")
+    log_prob_node = lsl.Calc(lambda lp: lp + 1.0, node.dist_node)
+    mb = lsl.GraphBuilder()
+    mb.add(node)
+    mb.log_lik_node = log_prob_node
+
+    model = mb.build_model()
+
+    state = model.state
+    interface = gs.LieselInterface(model)
+
+    updated_state = interface.update_state(gs.Position({"node": 1.0}), state)
+
+    # interface does not give access to likelihood, so it is directly accessed
+    # using the reserved node name
+    model_log_liks = jnp.array(
+        [state["_model_log_lik"].value, updated_state["_model_log_lik"].value]
+    )
+
+    log_probs = tfp.distributions.Normal(0.0, 1.0).log_prob(jnp.array([0.0, 1.0])) + 1.0
+
+    assert jnp.allclose(model_log_liks, log_probs)


### PR DESCRIPTION
The use of transient nodes internally created by the GraphBuilder raised issues when later querying the log_prob using the `LieselInterface` as the `TransientNode`s do not have a valid model state. This fixes the issue by using `Calc` nodes instead.

Also, introduced tests. However, the tests for log_prior and log_lik use the internal node names.