### PR TITLE
Implement Var.plot_vars and Model.plot_vars

### DIFF
--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -262,10 +262,12 @@ class GraphBuilder:
         return all_nodes, all_vars
 
     @staticmethod
-    def _do_set_missing_names(nodes_or_vars: Iterable[NV], prefix: str) -> None:
+    def _do_set_missing_names(nodes_or_vars: Iterable[NV], prefix: str) -> list[str]:
         """Sets the missing names for the given nodes or variables."""
         other = [nv.name for nv in nodes_or_vars if nv.name]
         counter = -1
+
+        automatically_set_names = []
 
         for nv in nodes_or_vars:
             if not nv.name:
@@ -276,13 +278,16 @@ class GraphBuilder:
 
                 nv.name = name
                 other.append(name)
+                automatically_set_names.append(name)
 
-    def _set_missing_names(self) -> GraphBuilder:
+        return automatically_set_names
+
+    def _set_missing_names(self) -> dict[str, list[str]]:
         """Sets the missing node and variable names."""
         nodes, _vars = self._all_nodes_and_vars()
-        self._do_set_missing_names(_vars, prefix="v")
-        self._do_set_missing_names(nodes, prefix="n")
-        return self
+        auto_var_names = self._do_set_missing_names(_vars, prefix="v")
+        auto_node_names = self._do_set_missing_names(nodes, prefix="n")
+        return {"vars": auto_var_names, "nodes": auto_node_names}
 
     def add(
         self, *args: Node | Var | GraphBuilder, to_float32: bool | None = None

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -1186,7 +1186,10 @@ class Model:
 
         return nodes, _vars
 
-    def node_subgraph(self, *of: Node) -> nx.DiGraph:
+    def node_parental_subgraph(self, *of: Node) -> nx.DiGraph:
+        """
+        Returns a subgraph that consists of the input nodes and their parent nodes.
+        """
         nodes_to_include = set()
         for node in of:
             nodes_to_include.update(nx.ancestors(self.node_graph, node))
@@ -1194,7 +1197,11 @@ class Model:
         subgraph = self.node_graph.subgraph(nodes_to_include)
         return subgraph
 
-    def var_subgraph(self, *of: Var) -> nx.DiGraph:
+    def var_parental_subgraph(self, *of: Var) -> nx.DiGraph:
+        """
+        Returns a subgraph that consists of the input variables and their parent
+        variables.
+        """
         nodes_to_include = set()
         for node in of:
             nodes_to_include.update(nx.ancestors(self.var_graph, node))

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -1186,6 +1186,22 @@ class Model:
 
         return nodes, _vars
 
+    def node_subgraph(self, *of: Node) -> nx.DiGraph:
+        nodes_to_include = set()
+        for node in of:
+            nodes_to_include.update(nx.ancestors(self.node_graph, node))
+            nodes_to_include.add(node)
+        subgraph = self.node_graph.subgraph(nodes_to_include)
+        return subgraph
+
+    def var_subgraph(self, *of: Var) -> nx.DiGraph:
+        nodes_to_include = set()
+        for node in of:
+            nodes_to_include.update(nx.ancestors(self.var_graph, node))
+            nodes_to_include.add(node)
+        subgraph = self.var_graph.subgraph(nodes_to_include)
+        return subgraph
+
     @property
     def log_lik(self) -> Array:
         """

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -1387,6 +1387,12 @@ class Model:
         brackets = f"({len(self._nodes)} nodes, {len(self._vars)} vars)"
         return type(self).__name__ + brackets
 
+    def plot_vars(self, **kwargs):
+        return plot_vars(self, **kwargs)
+
+    def plot_nodes(self, **kwargs):
+        return plot_nodes(self, **kwargs)
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Save and load models ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -11,7 +11,7 @@ from collections import Counter
 from collections.abc import Iterable
 from copy import deepcopy
 from types import MappingProxyType
-from typing import IO, Any, TypeVar
+from typing import IO, Any, Literal, TypeVar
 
 import dill
 import jax
@@ -1387,11 +1387,103 @@ class Model:
         brackets = f"({len(self._nodes)} nodes, {len(self._vars)} vars)"
         return type(self).__name__ + brackets
 
-    def plot_vars(self, **kwargs):
-        return plot_vars(self, **kwargs)
+    def plot_vars(
+        self,
+        show: bool = True,
+        save_path: str | None | IO = None,
+        width: int = 14,
+        height: int = 10,
+        prog: Literal[
+            "dot", "circo", "fdp", "neato", "osage", "patchwork", "sfdp", "twopi"
+        ] = "dot",
+    ):
+        """
+        Plots the variables of this model.
 
-    def plot_nodes(self, **kwargs):
-        return plot_nodes(self, **kwargs)
+        Wraps :func:`~.viz.plot_vars`.
+
+        Parameters
+        ----------
+        show
+            Whether to show the plot in a new window.
+        save_path
+            Path to save the plot. If not provided, the plot will not be saved.
+        width
+            Width of the plot in inches.
+        height
+            Height of the plot in inches.
+        prog
+            Layout parameter. Available layouts: circo, dot (the default), fdp, neato, \
+            osage, patchwork, sfdp, twopi.
+
+        See Also
+        --------
+        .Var.plot_vars : Plots the variables of the Liesel sub-model that terminates in
+            this variable.
+        .Var.plot_nodes : Plots the nodes of the Liesel sub-model that terminates in
+            this variable.
+        .Model.plot_vars : Plots the variables of a Liesel model.
+        .Model.plot_nodes : Plots the nodes of a Liesel model.
+        .viz.plot_vars : Plots the variables of a Liesel model.
+        .viz.plot_nodes : Plots the nodes of a Liesel model.
+        """
+        return plot_vars(
+            self,
+            show=show,
+            save_path=save_path,
+            width=width,
+            height=height,
+            prog=prog,
+        )
+
+    def plot_nodes(
+        self,
+        show: bool = True,
+        save_path: str | None | IO = None,
+        width: int = 14,
+        height: int = 10,
+        prog: Literal[
+            "dot", "circo", "fdp", "neato", "osage", "patchwork", "sfdp", "twopi"
+        ] = "dot",
+    ):
+        """
+        Plots the nodes of this model.
+
+        Wraps :func:`~.viz.plot_nodes`.
+
+        Parameters
+        ----------
+        show
+            Whether to show the plot in a new window.
+        save_path
+            Path to save the plot. If not provided, the plot will not be saved.
+        width
+            Width of the plot in inches.
+        height
+            Height of the plot in inches.
+        prog
+            Layout parameter. Available layouts: circo, dot (the default), fdp, neato, \
+            osage, patchwork, sfdp, twopi.
+
+        See Also
+        --------
+        .Var.plot_vars : Plots the variables of the Liesel sub-model that terminates in
+            this variable.
+        .Var.plot_nodes : Plots the nodes of the Liesel sub-model that terminates in
+            this variable.
+        .Model.plot_vars : Plots the variables of a Liesel model.
+        .Model.plot_nodes : Plots the nodes of a Liesel model.
+        .viz.plot_vars : Plots the variables of a Liesel model.
+        .viz.plot_nodes : Plots the nodes of a Liesel model.
+        """
+        return plot_nodes(
+            self,
+            show=show,
+            save_path=save_path,
+            width=width,
+            height=height,
+            prog=prog,
+        )
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -29,6 +29,7 @@ import tensorflow_probability.substrates.numpy.bijectors as nb
 import tensorflow_probability.substrates.numpy.distributions as nd
 
 from ..distributions.nodist import NoDistribution
+from .viz import plot_nodes, plot_vars
 
 if TYPE_CHECKING:
     from .model import Model
@@ -1920,12 +1921,17 @@ class Var:
     def _plot(
         self, which: Literal["vars", "nodes"] = "vars", verbose: bool = True, **kwargs
     ) -> None:
-        if self.model:
+
+        if self.model is not None:
             match which:
                 case "vars":
-                    return self.model.plot_vars()
+                    subgraph = self.model.var_subgraph(self)
+                    return plot_vars(subgraph, **kwargs)
                 case "nodes":
-                    return self.model.plot_nodes()
+                    self_nodes = [self.value_node, self.dist_node, self.var_value_node]
+                    filtered_nodes = [nd for nd in self_nodes if nd is not None]
+                    subgraph = self.model.node_subgraph(*filtered_nodes)
+                    return plot_nodes(subgraph, **kwargs)
 
         from liesel.model import GraphBuilder
 
@@ -1952,9 +1958,14 @@ class Var:
 
         match which:
             case "vars":
-                model.plot_vars(**kwargs)
+                subgraph = model.var_subgraph(self)
+                plot_vars(subgraph, **kwargs)
             case "nodes":
-                model.plot_nodes(**kwargs)
+                self_nodes = [self.value_node, self.dist_node, self.var_value_node]
+                self_nodes = [nd for nd in self_nodes if nd is not None]
+                filtered_nodes = [nd for nd in self_nodes if nd is not None]
+                subgraph = model.node_subgraph(*filtered_nodes)
+                plot_nodes(subgraph, **kwargs)
 
         model.pop_nodes_and_vars()
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1925,12 +1925,12 @@ class Var:
         if self.model is not None:
             match which:
                 case "vars":
-                    subgraph = self.model.var_subgraph(self)
+                    subgraph = self.model.var_parental_subgraph(self)
                     return plot_vars(subgraph, **kwargs)
                 case "nodes":
                     self_nodes = [self.value_node, self.dist_node, self.var_value_node]
                     filtered_nodes = [nd for nd in self_nodes if nd is not None]
-                    subgraph = self.model.node_subgraph(*filtered_nodes)
+                    subgraph = self.model.node_parental_subgraph(*filtered_nodes)
                     return plot_nodes(subgraph, **kwargs)
 
         from liesel.model import GraphBuilder
@@ -1958,13 +1958,13 @@ class Var:
 
         match which:
             case "vars":
-                subgraph = model.var_subgraph(self)
+                subgraph = model.var_parental_subgraph(self)
                 plot_vars(subgraph, **kwargs)
             case "nodes":
                 self_nodes = [self.value_node, self.dist_node, self.var_value_node]
                 self_nodes = [nd for nd in self_nodes if nd is not None]
                 filtered_nodes = [nd for nd in self_nodes if nd is not None]
-                subgraph = model.node_subgraph(*filtered_nodes)
+                subgraph = model.node_parental_subgraph(*filtered_nodes)
                 plot_nodes(subgraph, **kwargs)
 
         model.pop_nodes_and_vars()

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1960,7 +1960,7 @@ class Var:
         return f'{type(self).__name__}(name="{self.name}")'
 
     def _plot(
-        self, which: Literal["vars", "nodes"] = "vars", verbose: bool = True, **kwargs
+        self, which: Literal["vars", "nodes"] = "vars", verbose: bool = False, **kwargs
     ) -> None:
 
         if self.model is not None:
@@ -1982,17 +1982,25 @@ class Var:
         automatically_set_names = gb._set_missing_names()
         var_names = automatically_set_names["vars"]
         node_names = automatically_set_names["nodes"]
-        if var_names and verbose:
+        if var_names:
+            if verbose:
+                names_ = f"The automatically assigned names are: {var_names}. "
+            else:
+                names_ = ""
             logger.info(
-                "Unnamed variables were temporarily named for plotting. The"
-                f" automatically assigned names are: {var_names}. The names are reset"
+                f"Unnamed variables were temporarily named for plotting. {names_}"
+                "The names are reset"
                 " after plotting."
             )
-        if node_names and verbose:
+        if node_names:
+            if verbose:
+                names_ = f"The automatically assigned names are: {node_names}. "
+            else:
+                names_ = ""
             logger.info(
-                "Unnamed nodes were temporarily named for plottingThe automatically"
-                f" assigned names are: {node_names}. The names are reset after"
-                " plotting."
+                f"Unnamed nodes were temporarily named for plotting. {names_}"
+                "The names are reset"
+                " after plotting."
             )
 
         model = gb.build_model()
@@ -2024,7 +2032,6 @@ class Var:
 
     def plot_vars(
         self,
-        verbose: bool = True,
         show: bool = True,
         save_path: str | None | IO = None,
         width: int = 14,
@@ -2032,6 +2039,7 @@ class Var:
         prog: Literal[
             "dot", "circo", "fdp", "neato", "osage", "patchwork", "sfdp", "twopi"
         ] = "dot",
+        verbose: bool = False,
     ) -> None:
         """
         Plots the variables of the Liesel sub-model that terminates in this variable.
@@ -2054,6 +2062,10 @@ class Var:
         prog
             Layout parameter. Available layouts: circo, dot (the default), fdp, neato, \
             osage, patchwork, sfdp, twopi.
+        verbose
+            If ``True``, the message that will be logged if unnamed nodes are \
+            automatically named for plotting contains a list of the automatically \
+            assigned names.
 
         See Also
         --------
@@ -2078,7 +2090,6 @@ class Var:
 
     def plot_nodes(
         self,
-        verbose: bool = True,
         show: bool = True,
         save_path: str | None | IO = None,
         width: int = 14,
@@ -2086,6 +2097,7 @@ class Var:
         prog: Literal[
             "dot", "circo", "fdp", "neato", "osage", "patchwork", "sfdp", "twopi"
         ] = "dot",
+        verbose: bool = False,
     ) -> None:
         """
         Plots the nodes of the Liesel sub-model that terminates in this variable.
@@ -2108,6 +2120,10 @@ class Var:
         prog
             Layout parameter. Available layouts: circo, dot (the default), fdp, neato, \
             osage, patchwork, sfdp, twopi.
+        verbose
+            If ``True``, the message that will be logged if unnamed nodes are \
+            automatically named for plotting contains a list of the automatically \
+            assigned names.
 
         See Also
         --------

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -2011,7 +2011,6 @@ class Var:
                 plot_vars(subgraph, **kwargs)
             case "nodes":
                 self_nodes = [self.value_node, self.dist_node, self.var_value_node]
-                self_nodes = [nd for nd in self_nodes if nd is not None]
                 filtered_nodes = [nd for nd in self_nodes if nd is not None]
                 subgraph = model.node_parental_subgraph(*filtered_nodes)
                 plot_nodes(subgraph, **kwargs)

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -12,7 +12,16 @@ from collections.abc import Callable, Hashable, Iterable
 from functools import wraps
 from itertools import chain
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeGuard, TypeVar, Union
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    NamedTuple,
+    TypeGuard,
+    TypeVar,
+    Union,
+)
 
 import tensorflow_probability.substrates.jax.bijectors as jb
 import tensorflow_probability.substrates.jax.distributions as jd
@@ -1961,11 +1970,113 @@ class Var:
         gb.nodes.clear()
         gb.vars.clear()
 
-    def plot_vars(self, verbose: bool = True, **kwargs) -> None:
-        return self._plot(which="vars", verbose=verbose, **kwargs)
+    def plot_vars(
+        self,
+        verbose: bool = True,
+        show: bool = True,
+        save_path: str | None | IO = None,
+        width: int = 14,
+        height: int = 10,
+        prog: Literal[
+            "dot", "circo", "fdp", "neato", "osage", "patchwork", "sfdp", "twopi"
+        ] = "dot",
+    ) -> None:
+        """
+        Plots the variables of the Liesel sub-model that terminates in this variable.
 
-    def plot_nodes(self, verbose: bool = True, **kwargs) -> None:
-        return self._plot(which="nodes", verbose=verbose, **kwargs)
+        Wraps :func:`~.viz.plot_vars`.
+
+        Parameters
+        ----------
+        verbose
+            If ``True``, logs a message if unnamed variables or nodes are temporarily \
+            named for plotting.
+        show
+            Whether to show the plot in a new window.
+        save_path
+            Path to save the plot. If not provided, the plot will not be saved.
+        width
+            Width of the plot in inches.
+        height
+            Height of the plot in inches.
+        prog
+            Layout parameter. Available layouts: circo, dot (the default), fdp, neato, \
+            osage, patchwork, sfdp, twopi.
+
+        See Also
+        --------
+        .Var.plot_vars : Plots the variables of the Liesel sub-model that terminates in
+            this variable.
+        .Var.plot_nodes : Plots the nodes of the Liesel sub-model that terminates in
+            this variable.
+        .Model.plot_vars : Plots the variables of a Liesel model.
+        .Model.plot_nodes : Plots the nodes of a Liesel model.
+        .viz.plot_vars : Plots the variables of a Liesel model.
+        .viz.plot_nodes : Plots the nodes of a Liesel model.
+        """
+        return self._plot(
+            which="vars",
+            verbose=verbose,
+            show=show,
+            save_path=save_path,
+            width=width,
+            height=height,
+            prog=prog,
+        )
+
+    def plot_nodes(
+        self,
+        verbose: bool = True,
+        show: bool = True,
+        save_path: str | None | IO = None,
+        width: int = 14,
+        height: int = 10,
+        prog: Literal[
+            "dot", "circo", "fdp", "neato", "osage", "patchwork", "sfdp", "twopi"
+        ] = "dot",
+    ) -> None:
+        """
+        Plots the nodes of the Liesel sub-model that terminates in this variable.
+
+        Wraps :func:`~.viz.plot_nodes`.
+
+        Parameters
+        ----------
+        verbose
+            If ``True``, logs a message if unnamed variables or nodes are temporarily \
+            named for plotting.
+        show
+            Whether to show the plot in a new window.
+        save_path
+            Path to save the plot. If not provided, the plot will not be saved.
+        width
+            Width of the plot in inches.
+        height
+            Height of the plot in inches.
+        prog
+            Layout parameter. Available layouts: circo, dot (the default), fdp, neato, \
+            osage, patchwork, sfdp, twopi.
+
+        See Also
+        --------
+        .Var.plot_vars : Plots the variables of the Liesel sub-model that terminates in
+            this variable.
+        .Var.plot_nodes : Plots the nodes of the Liesel sub-model that terminates in
+            this variable.
+        .Model.plot_vars : Plots the variables of a Liesel model.
+        .Model.plot_nodes : Plots the nodes of a Liesel model.
+        .viz.plot_vars : Plots the variables of a Liesel model.
+        .viz.plot_nodes : Plots the nodes of a Liesel model.
+        """
+        return self._plot(
+            which="nodes",
+            verbose=verbose,
+            show=show,
+            save_path=save_path,
+            width=width,
+            height=height,
+            prog=prog,
+        )
 
 
 def _transform_var_with_bijector_instance(var: Var, bijector_inst: jb.Bijector) -> Var:

--- a/liesel/model/viz.py
+++ b/liesel/model/viz.py
@@ -53,14 +53,17 @@ def plot_nodes(
     .viz.plot_nodes : Plots the nodes of a Liesel model.
     """
 
-    colors = [
-        "#fc8d62" if node.outdated else "#8da0cb" for node in model.node_graph.nodes
-    ]
+    try:
+        graph = model.node_graph
+    except AttributeError:
+        graph = model
 
-    _, axis, pos = _prepare_figure(model.node_graph, width, height, prog)
-    nx.draw_networkx_nodes(model.node_graph, pos, node_color=colors, ax=axis)
-    _add_labels(model.node_graph, axis, pos)
-    _draw_edges(model.node_graph, axis, pos, False)
+    colors = ["#fc8d62" if node.outdated else "#8da0cb" for node in graph.nodes]
+
+    _, axis, pos = _prepare_figure(graph, width, height, prog)
+    nx.draw_networkx_nodes(graph, pos, node_color=colors, ax=axis)
+    _add_labels(graph, axis, pos)
+    _draw_edges(graph, axis, pos, False)
 
     if save_path:
         plt.savefig(save_path)
@@ -108,12 +111,16 @@ def plot_vars(
     .viz.plot_vars : Plots the variables of a Liesel model.
     .viz.plot_nodes : Plots the nodes of a Liesel model.
     """
+    try:
+        graph = model.var_graph
+    except AttributeError:
+        graph = model
 
-    _, axis, pos = _prepare_figure(model.var_graph, width, height, prog)
-    _add_nodes_with_distribution_to_plot(model.var_graph, axis, pos)
-    _add_nodes_without_distribution_to_plot(model.var_graph, axis, pos)
-    _add_labels(model.var_graph, axis, pos)
-    _draw_edges(model.var_graph, axis, pos, True)
+    _, axis, pos = _prepare_figure(graph, width, height, prog)
+    _add_nodes_with_distribution_to_plot(graph, axis, pos)
+    _add_nodes_without_distribution_to_plot(graph, axis, pos)
+    _add_labels(graph, axis, pos)
+    _draw_edges(graph, axis, pos, True)
     _add_legend(axis)
 
     if save_path:

--- a/liesel/model/viz.py
+++ b/liesel/model/viz.py
@@ -3,6 +3,7 @@ Model visualization.
 """
 
 import logging
+from typing import IO, Literal
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -11,7 +12,16 @@ from matplotlib.lines import Line2D
 logger = logging.getLogger(__name__)
 
 
-def plot_nodes(model, show=True, save_path=None, width=14, height=10, prog="dot"):
+def plot_nodes(
+    model,
+    show: bool = True,
+    save_path: str | None | IO = None,
+    width: int = 14,
+    height: int = 10,
+    prog: Literal[
+        "dot", "circo", "fdp", "neato", "osage", "patchwork", "sfdp", "twopi"
+    ] = "dot",
+):
     """
     Plots the nodes of a Liesel model.
 
@@ -28,8 +38,19 @@ def plot_nodes(model, show=True, save_path=None, width=14, height=10, prog="dot"
     height
         Height of the plot in inches.
     prog
-        Layout parameter. Available layouts: circo, dot (the default), fdp, neato,
+        Layout parameter. Available layouts: circo, dot (the default), fdp, neato, \
         osage, patchwork, sfdp, twopi.
+
+    See Also
+    --------
+    .Var.plot_vars : Plots the variables of the Liesel sub-model that terminates in
+        this variable.
+    .Var.plot_nodes : Plots the nodes of the Liesel sub-model that terminates in
+        this variable.
+    .Model.plot_vars : Plots the variables of a Liesel model.
+    .Model.plot_nodes : Plots the nodes of a Liesel model.
+    .viz.plot_vars : Plots the variables of a Liesel model.
+    .viz.plot_nodes : Plots the nodes of a Liesel model.
     """
 
     colors = [
@@ -47,7 +68,16 @@ def plot_nodes(model, show=True, save_path=None, width=14, height=10, prog="dot"
         plt.show()
 
 
-def plot_vars(model, show=True, save_path=None, width=14, height=10, prog="dot"):
+def plot_vars(
+    model,
+    show: bool = True,
+    save_path: str | None | IO = None,
+    width: int = 14,
+    height: int = 10,
+    prog: Literal[
+        "dot", "circo", "fdp", "neato", "osage", "patchwork", "sfdp", "twopi"
+    ] = "dot",
+):
     """
     Plots the variables of a Liesel model.
 
@@ -66,6 +96,17 @@ def plot_vars(model, show=True, save_path=None, width=14, height=10, prog="dot")
     prog
         Layout parameter. Available layouts: circo, dot (the default), fdp, neato,
         osage, patchwork, sfdp, twopi.
+
+    See Also
+    --------
+    .Var.plot_vars : Plots the variables of the Liesel sub-model that terminates in
+        this variable.
+    .Var.plot_nodes : Plots the nodes of the Liesel sub-model that terminates in
+        this variable.
+    .Model.plot_vars : Plots the variables of a Liesel model.
+    .Model.plot_nodes : Plots the nodes of a Liesel model.
+    .viz.plot_vars : Plots the variables of a Liesel model.
+    .viz.plot_nodes : Plots the nodes of a Liesel model.
     """
 
     _, axis, pos = _prepare_figure(model.var_graph, width, height, prog)


### PR DESCRIPTION
All of the below applies to `plot_vars` as well as `plot_nodes`.

This PR adds methods to the `lsl.Var` and the `lsl.Model` objects that wrap the referenced plotting functions. The method on `lsl.Model` is inspired by the corresponding `lsl.GraphBuilder.plot_vars` method, which has existed for a long time and I find quite convenient.

The `lsl.Var.plot_vars` brings more novelty, because it is a way to very quickly plot intermediate sub-models. One tricky bit was to deal with the automatic naming: As soon as you initialize a model, Liesel will automatically assign names to unnamed nodes. Because `lsl.plot_vars` works similar to `lsl.GraphBuilder.plot_vars`, this also happens here: A helper model is built, then the plot is created, then the helper model is discarded. The issue is: The previously unnamed nodes keep their new names. I think this is not intended behavior, so the `lsl.Var.plot_vars` method resets the automatically assigned names after plotting. It also emits a logging message that notifies users of this behavior, because I think otherwise it could be confusing.

`lsl.Var.plot_vars` will not work for variables that are already part of a model, because in this case, no intermediate model can be created.

In `lsl.Var.plot_nodes`, the three model nodes (log_prob, log_lik, log_prior) will also show up. I think this is ok. This plot is intended for advanced users anyway, and having the three log prob nodes in there allows users to spot potential issues with the likelihood and prior attribution in their subgraph.

## Example

```python
>>> import liesel.model as lsl
>>> a = lsl.Var.new_value(1.0)
>>> b = lsl.Var.new_calc(lambda a: a + 1.0, a=a, name="b")
```

```python
>>> a.name
''
```

```python
>>> b.plot_vars()
liesel.model.nodes - INFO - Unnamed variables were temporarily named for plotting. The automatically assigned names are: ['v0']. The names are reset after plotting.
```

![image](https://github.com/user-attachments/assets/790522b7-218b-47ca-8eee-cd1e2fb613ec)


```python
>>> b.plot_nodes()
liesel.model.nodes - INFO - Unnamed variables were temporarily named for plotting. The automatically assigned names are: ['v0']. The names are reset after plotting.
```

![image](https://github.com/user-attachments/assets/59cbc689-4aa8-4eb3-9fe8-306306a01129)

Note: In this example, the three model nodes are unconnected, because there is no node with a probability in the minimal example model.

```python
>>> a.name
''
```
