### PR TITLE
Adds edge to plot_vars if input is used in value while var has distribution

### DIFF
--- a/liesel/model/viz.py
+++ b/liesel/model/viz.py
@@ -173,9 +173,11 @@ def _draw_edges(graph, axis, pos, is_var):
 
     if is_var:
         dist_edges = []
-        non_dist_edges = []
+        value_edges = []
 
         for edge in edges:
+
+            # find distribution edges
             if edge[1].has_dist:
                 edge_0_output_nodes = set(edge[0].all_output_nodes())
                 edge_0_nodes = edge[0].nodes
@@ -183,8 +185,31 @@ def _draw_edges(graph, axis, pos, is_var):
 
                 if bool(edge_0_output_nodes.union(edge_0_nodes) & edge_1_input_nodes):
                     dist_edges.append(edge)
-            else:
-                non_dist_edges.append(edge)
+
+            # find value edges
+            edge_0_output_nodes = set(edge[0].all_output_nodes())
+            edge_0_nodes = edge[0].nodes
+            edge_1_input_nodes = set(edge[1].value_node.all_input_nodes())
+
+            if bool(edge_0_output_nodes.union(edge_0_nodes) & edge_1_input_nodes):
+                value_edges.append(edge)
+
+        edges_in_both = set(dist_edges) & set(value_edges)
+        dist_edges = set(dist_edges) - edges_in_both
+        value_edges = set(value_edges) - edges_in_both
+
+        # assigns value_edges to edges to make it comparible with is_var=False
+        edges = value_edges
+
+        nx.draw_networkx_edges(
+            graph,
+            pos,
+            edgelist=edges_in_both,
+            edge_color="#FF0000",
+            arrows=True,
+            ax=axis,
+            node_size=500,
+        )
 
         nx.draw_networkx_edges(
             graph,
@@ -195,8 +220,6 @@ def _draw_edges(graph, axis, pos, is_var):
             ax=axis,
             node_size=500,
         )
-
-        edges = non_dist_edges
 
     nx.draw_networkx_edges(
         graph,
@@ -247,8 +270,18 @@ def _add_legend(axis):
             [0],
             [0],
             marker=r"$\rightarrow$",
-            color="#aaaaaa",
+            color="#AAAAAA",
             label="Used in distribution",
+            markerfacecolor="k",
+            markersize=12,
+            lw=0,
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker=r"$\rightarrow$",
+            color="#FF0000",
+            label="Used in value and distribution",
             markerfacecolor="k",
             markersize=12,
             lw=0,


### PR DESCRIPTION
Fixes #217.

Adds an edge if input is used in value of a node that has also a distribution. Introduces a red edge if input is used in value and dist node.

Changes the created by the code
```py
import liesel.model as lsl
import jax.numpy as jnp
import tensorflow_probability.substrates.jax.distributions as tfd

# create a model
x = lsl.Var(jnp.arange(4).astype(float), name="x")
y = lsl.Var(jnp.arange(4).astype(float), name="y")
batch_index = lsl.Var(
    jnp.array([0, 1]),
    name="batch_index",
)
y_sel_dist = lsl.Dist(lambda x, idx: tfd.Normal(x[idx], 1.0), x, batch_index)
y_sel_val = lsl.Calc(lambda y, idx: y[idx], y, batch_index)
y_sel_val.value
y_sel = lsl.Var(
    y_sel_val,
    y_sel_dist,
    "y_sel",
)

model = lsl.GraphBuilder().add(y_sel_dist).build_model()
lsl.plot_vars(model)
```
from
![old](https://github.com/user-attachments/assets/bbd9ee8a-2a96-4d0d-8772-d7c6c23a4d6e)
to
![new](https://github.com/user-attachments/assets/5bd6c4a3-3c41-4cc9-a49b-59254b5e8c0f)

