### PR TITLE
Weaken jax version pin to <0.5.0, closes #214

### DIFF
--- a/liesel/goose/optim.py
+++ b/liesel/goose/optim.py
@@ -360,7 +360,6 @@ def optim_flat(
     user_patience = stopper.patience
     if model_validation is None:
         model_validation = model_train
-        stopper.patience = stopper.max_iter
 
     if optimizer is None:
         optimizer = optax.adam(learning_rate=1e-2)

--- a/liesel/goose/optim.py
+++ b/liesel/goose/optim.py
@@ -462,25 +462,34 @@ def optim_flat(
     # ---------------------------------------------------------------------------------
     # Initialize while loop carry dictionary
 
-    progress_bar = tqdm(
-        total=stopper.max_iter - 1,
-        desc=(
-            f"Training loss: {loss_train_start:.3f}, Validation loss:"
-            f" {loss_validation_start:.3f}"
-        ),
-        position=0,
-        leave=True,
-    )
-
-    def tqdm_callback(val):
-        i = val["while_i"]
-        loss_train = val["history"]["loss_train"][i]
-        loss_validation = val["history"]["loss_validation"][i]
-        desc = (
-            f"Training loss: {loss_train:.3f}, Validation loss: {loss_validation:.3f}"
+    if progress_bar:
+        progress_bar_inst = tqdm(
+            total=stopper.max_iter,
+            desc=(
+                f"Training loss: {loss_train_start:.3f}, Validation loss:"
+                f" {loss_validation_start:.3f}"
+            ),
+            position=0,
+            leave=True,
         )
-        progress_bar.update(1)
-        progress_bar.set_description(desc)
+
+        def tqdm_callback(val):
+            i = val["while_i"]
+            loss_train = val["history"]["loss_train"][i]
+            loss_validation = val["history"]["loss_validation"][i]
+            desc = (
+                f"Training loss: {loss_train:.3f}, Validation loss:"
+                f" {loss_validation:.3f}"
+            )
+            progress_bar_inst.update(1)
+            progress_bar_inst.set_description(desc)
+
+        tqdm_callback(init_val)
+
+    else:
+
+        def tqdm_callbacl(val):
+            return None
 
     # ---------------------------------------------------------------------------------
     # Define while loop body

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ install_requires =
     blackjax>=1.0
     deprecated>=1.2
     dill>=0.3
-    jax>=0.4.1,<=0.4.31
-    jaxlib>=0.4.1,<=0.4.31
+    jax>=0.4.1
+    jaxlib>=0.4.1
     matplotlib>=3.5
     networkx>=2.6
     numpy>=1.22,!=1.24.0,<2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ install_requires =
     blackjax>=1.0
     deprecated>=1.2
     dill>=0.3
-    jax>=0.4.1
-    jaxlib>=0.4.1
+    jax>=0.4.1,<0.5.0
+    jaxlib>=0.4.1,<0.5.0
     matplotlib>=3.5
     networkx>=2.6
     numpy>=1.22,!=1.24.0,<2.0


### PR DESCRIPTION
The issue in our code originated in the `liesel.goose.optim` module, specifically in the callback that updates the progress bar.

In the callback, the current loss values were accessed like this:

```python
i = val["while_i"]
loss_train = val["history"]["loss_train"][i]
loss_validation = val["history"]["loss_validation"][i]
```

Some experimentation revealed that this pattern was the problem. Introducing dedicated `"current_loss_train"` and `"current_loss_validation"` carry values solved the issue:

```python
loss_train = val["current_loss_train"]
loss_validation = val["current_loss_validation"]
```

While I was at it, I fixed two other issues with the progress bar:

1. There was a bug that prevented the argument `progress_bar=False` from taking effect, i.e. the progress bar couldn't be turned off. This is fixed now.
2. The progress bar displayed `max_iter-1` as the total number of iterations. This is fixed now.
3. When a user defines a gs.Stopper(patience=10) and does not pass a model_validation, they will have reason to expect early stopping to be performed based on the training model. Previously, this belief was false. Now this belief is true.