### PR TITLE
Fix test warnings

### DIFF
--- a/docs/source/tutorials/qmd/01a-transform.qmd
+++ b/docs/source/tutorials/qmd/01a-transform.qmd
@@ -48,16 +48,16 @@ y_vec = X_mat @ true_beta + rng.normal(scale=true_sigma, size=n)
 # Model
 # Part 1: Model for the mean
 beta_prior = lsl.Dist(tfd.Normal, loc=0.0, scale=100.0)
-beta = lsl.param(value=np.array([0.0, 0.0]), distribution=beta_prior,name="beta")
+beta = lsl.Var.new_param(value=np.array([0.0, 0.0]), distribution=beta_prior,name="beta")
 
-X = lsl.obs(X_mat, name="X")
+X = lsl.Var.new_obs(X_mat, name="X")
 mu = lsl.Var(lsl.Calc(jnp.dot, X, beta), name="mu")
 
 # Part 2: Model for the standard deviation
 a = lsl.Var(0.01, name="a")
 b = lsl.Var(0.01, name="b")
 sigma_sq_prior = lsl.Dist(tfd.InverseGamma, concentration=a, scale=b)
-sigma_sq = lsl.param(value=10.0, distribution=sigma_sq_prior, name="sigma_sq")
+sigma_sq = lsl.Var.new_param(value=10.0, distribution=sigma_sq_prior, name="sigma_sq")
 
 sigma = lsl.Var(lsl.Calc(jnp.sqrt, sigma_sq), name="sigma")
 

--- a/docs/source/tutorials/qmd/02-ls-reg.qmd
+++ b/docs/source/tutorials/qmd/02-ls-reg.qmd
@@ -108,10 +108,10 @@ The variables `beta` and `gamma` are initialized with values far away from zero 
 ```{python}
 #| label: coefficients
 dist_beta = lsl.Dist(tfd.Normal, loc=0.0, scale=100.0)
-beta = lsl.param(jnp.array([10., 10.]), dist_beta, name="beta")
+beta = lsl.Var.new_param(jnp.array([10., 10.]), dist_beta, name="beta")
 
 dist_gamma = lsl.Dist(tfd.Normal, loc=0.0, scale=100.0)
-gamma = lsl.param(jnp.array([5., 5.]), dist_gamma, name="gamma")
+gamma = lsl.Var.new_param(jnp.array([5., 5.]), dist_gamma, name="gamma")
 ```
 
 The additional complexity of the location-scale model compared to the standard linear model is handled in the next step.
@@ -119,8 +119,8 @@ Since `gamma` takes values on the whole real line, but the response variable `y`
 
 ```{python}
 #| label: observation-nodes
-X = lsl.obs(X_mat, name="X")
-Z = lsl.obs(Z_mat, name="Z")
+X = lsl.Var.new_obs(X_mat, name="X")
+Z = lsl.Var.new_obs(Z_mat, name="Z")
 
 mu = lsl.Var(lsl.Calc(jnp.dot, X, beta), name="mu")
 
@@ -128,7 +128,7 @@ log_scale = lsl.Calc(jnp.dot, Z, gamma)
 scale = lsl.Var(lsl.Calc(jnp.exp, log_scale), name="scale")
 
 dist_y = lsl.Dist(tfd.Normal, loc=mu, scale=scale)
-y = lsl.obs(y_vec, dist_y, name="y")
+y = lsl.Var.new_obs(y_vec, dist_y, name="y")
 ```
 
 We can now combine the nodes in a model and visualize it

--- a/docs/source/tutorials/qmd/07-groups.qmd
+++ b/docs/source/tutorials/qmd/07-groups.qmd
@@ -98,7 +98,7 @@ class VarianceIG(lsl.Group):
         b_var = lsl.Var(b, name=f"{name}_b")
 
         prior = lsl.Dist(tfd.InverseGamma, concentration=a_var, scale=b_var)
-        tau2 = lsl.param(start_value, distribution=prior, name=name)
+        tau2 = lsl.Var.new_param(start_value, distribution=prior, name=name)
         super().__init__(name=name, a=a_var, b=b_var, tau2=tau2)
 ```
 
@@ -128,7 +128,7 @@ class SplineCoef(lsl.Group):
         )
         start_value = np.zeros(np.shape(penalty)[-1], np.float32)
 
-        coef = lsl.param(start_value, distribution=prior, name=name)
+        coef = lsl.Var.new_param(start_value, distribution=prior, name=name)
 
         super().__init__(name, coef=coef, penalty=penalty_var, tau2=tau2, rank=rank)
 
@@ -197,7 +197,7 @@ class PSpline(lsl.Group):
             name=f"{name}_coef", penalty=penalty, tau2=tau2_group["tau2"]
         )
 
-        basis_matrix = lsl.obs(basis_matrix, name=f"{name}_basis_matrix")
+        basis_matrix = lsl.Var.new_obs(basis_matrix, name=f"{name}_basis_matrix")
         smooth = lsl.Var(
             lsl.Calc(jnp.dot, basis_matrix, coef_group["coef"]), name=name
         )
@@ -333,7 +333,7 @@ class VarianceIG(lsl.Group):
 
         prior = lsl.Dist(tfd.InverseGamma, concentration=self.a, scale=self.b)
 
-        self.tau2 = lsl.param(start_value, distribution=prior, name=name)
+        self.tau2 = lsl.Var.new_param(start_value, distribution=prior, name=name)
         """Variance parameter variable."""
 
         super().__init__(name=name, a=self.a, b=self.b, tau2=self.tau2)

--- a/liesel/goose/builder.py
+++ b/liesel/goose/builder.py
@@ -100,9 +100,9 @@ class EngineBuilder:
 
     First, we set up a minimal model:
 
-    >>> mu = lsl.param(0.0, name="mu")
+    >>> mu = lsl.Var.new_param(0.0, name="mu")
     >>> dist = lsl.Dist(tfd.Normal, loc=mu, scale=1.0)
-    >>> y = lsl.obs(jnp.array([1.0, 2.0, 3.0]), dist, name="y")
+    >>> y = lsl.Var.new_obs(jnp.array([1.0, 2.0, 3.0]), dist, name="y")
     >>> model = lsl.GraphBuilder().add(y).build_model()
 
     Now we initialize the EngineBuilder and set the desired number of warmup and
@@ -177,10 +177,10 @@ class EngineBuilder:
         parameter in a normal distribution and take the exponential value for including
         the actual scale:
 
-        >>> log_scale = lsl.param(0.0, name="log_scale")
+        >>> log_scale = lsl.Var.new_param(0.0, name="log_scale")
         >>> scale = lsl.Calc(jnp.exp, variance, _name="scale")
         >>> dist = lsl.Dist(tfd.Normal, loc=0.0, scale=scale)
-        >>> y = lsl.obs(jnp.array([1.0, 2.0, 3.0]), dist, name="y")
+        >>> y = lsl.Var.new_obs(jnp.array([1.0, 2.0, 3.0]), dist, name="y")
         >>> model = lsl.GraphBuilder().add(y).build_model()
 
         Now we might want to set up an engine builder with a NUTS kernel for the
@@ -293,7 +293,7 @@ class EngineBuilder:
         Then, we define the distribution we want to sample from, which is
         parametrized by a single parameter `mu`.
 
-        >>> mu = lsl.param(1.0, name="mu")
+        >>> mu = lsl.Var.new_param(1.0, name="mu")
         >>> x_dist = lsl.Dist(tfd.Normal, loc=true_mu, scale=true_sigma)
         >>> x = lsl.Var(x_vec, distribution=x_dist, name="x")
 

--- a/liesel/goose/interface.py
+++ b/liesel/goose/interface.py
@@ -254,7 +254,7 @@ class LieselInterface:
     First, we initialize a Liesel model. This is a minimal example only for the purpose
     of demonstrating how to use the interface.
 
-    >>> y = lsl.obs(jnp.array([1.0, 2.0, 3.0]), name="y")
+    >>> y = lsl.Var.new_obs(jnp.array([1.0, 2.0, 3.0]), name="y")
     >>> model = lsl.GraphBuilder().add(y).build_model()
 
     The interface is initialized by passing the model to the constructor.

--- a/liesel/goose/optim.py
+++ b/liesel/goose/optim.py
@@ -321,11 +321,11 @@ def optim_flat(
     Next, set up a linear model. For simplicity, we assume the scale to be fixed to the
     true value of 1.
 
-    >>> coef = lsl.param(jnp.zeros(2), name="coef")
-    >>> xvar = lsl.obs(jnp.c_[jnp.ones_like(x), x], name="x")
+    >>> coef = lsl.Var.new_param(jnp.zeros(2), name="coef")
+    >>> xvar = lsl.Var.new_obs(jnp.c_[jnp.ones_like(x), x], name="x")
     >>> mu = lsl.Var(lsl.Calc(jnp.dot, xvar, coef), name="mu")
     >>> ydist = lsl.Dist(tfd.Normal, loc=mu, scale=1.0)
-    >>> yvar = lsl.obs(y, ydist, name="y")
+    >>> yvar = lsl.Var.new_obs(y, ydist, name="y")
     >>> model = lsl.GraphBuilder().add(yvar).build_model()
 
     Now, we are ready to run the optimization.

--- a/liesel/goose/optim.py
+++ b/liesel/goose/optim.py
@@ -360,7 +360,6 @@ def optim_flat(
     user_patience = stopper.patience
     if model_validation is None:
         model_validation = model_train
-        stopper.patience = stopper.max_iter
 
     if optimizer is None:
         optimizer = optax.adam(learning_rate=1e-2)

--- a/liesel/goose/optim.py
+++ b/liesel/goose/optim.py
@@ -462,25 +462,34 @@ def optim_flat(
     # ---------------------------------------------------------------------------------
     # Initialize while loop carry dictionary
 
-    progress_bar = tqdm(
-        total=stopper.max_iter - 1,
-        desc=(
-            f"Training loss: {loss_train_start:.3f}, Validation loss:"
-            f" {loss_validation_start:.3f}"
-        ),
-        position=0,
-        leave=True,
-    )
-
-    def tqdm_callback(val):
-        i = val["while_i"]
-        loss_train = val["history"]["loss_train"][i]
-        loss_validation = val["history"]["loss_validation"][i]
-        desc = (
-            f"Training loss: {loss_train:.3f}, Validation loss: {loss_validation:.3f}"
+    if progress_bar:
+        progress_bar_inst = tqdm(
+            total=stopper.max_iter,
+            desc=(
+                f"Training loss: {loss_train_start:.3f}, Validation loss:"
+                f" {loss_validation_start:.3f}"
+            ),
+            position=0,
+            leave=True,
         )
-        progress_bar.update(1)
-        progress_bar.set_description(desc)
+
+        def tqdm_callback(val):
+            i = val["while_i"]
+            loss_train = val["history"]["loss_train"][i]
+            loss_validation = val["history"]["loss_validation"][i]
+            desc = (
+                f"Training loss: {loss_train:.3f}, Validation loss:"
+                f" {loss_validation:.3f}"
+            )
+            progress_bar_inst.update(1)
+            progress_bar_inst.set_description(desc)
+
+        tqdm_callback(init_val)
+
+    else:
+
+        def tqdm_callbacl(val):
+            return None
 
     # ---------------------------------------------------------------------------------
     # Define while loop body

--- a/liesel/model/legacy.py
+++ b/liesel/model/legacy.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 import jax.numpy as jnp
 
 from .nodes import Bijector as TFPBijector
-from .nodes import Calc, Dist, Node, Var, obs, param
+from .nodes import Calc, Dist, Node, Var
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Strong variables ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -21,7 +21,7 @@ def DesignMatrix(
     value: Any | Calc, distribution: Dist | None = None, name: str = ""
 ) -> Var:
     """A strong variable representing a design matrix."""
-    var = obs(value, distribution, name)
+    var = Var.new_obs(value, distribution, name)
     var.role = "DesignMatrix"
     return var
 
@@ -39,7 +39,7 @@ def Parameter(
     value: Any | Calc, distribution: Dist | None = None, name: str = ""
 ) -> Var:
     """A strong variable representing a model parameter."""
-    var = param(value, distribution, name)
+    var = Var.new_param(value, distribution, name)
     var.role = "Parameter"
     return var
 
@@ -48,7 +48,7 @@ def RegressionCoef(
     value: Any | Calc, distribution: Dist | None = None, name: str = ""
 ) -> Var:
     """A strong variable representing a vector of regression coefficients."""
-    var = param(value, distribution, name)
+    var = Var.new_param(value, distribution, name)
     var.role = "RegressionCoef"
     return var
 
@@ -57,7 +57,7 @@ def Response(
     value: Any | Calc, distribution: Dist | None = None, name: str = ""
 ) -> Var:
     """A strong variable representing a response vector."""
-    var = obs(value, distribution, name)
+    var = Var.new_obs(value, distribution, name)
     var.role = "Response"
     return var
 
@@ -66,7 +66,7 @@ def SmoothingParam(
     value: Any | Calc, distribution: Dist | None = None, name: str = ""
 ) -> Var:
     """A strong variable representing a smoothing parameter."""
-    var = param(value, distribution, name)
+    var = Var.new_param(value, distribution, name)
     var.role = "SmoothingParam"
     return var
 
@@ -194,7 +194,7 @@ def Obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
     Declares an observed variable.
 
     .. deprecated:: 0.2.6
-        Use lsl.obs() instead. This alias will be removed in v0.4.0
+        Use lsl.Var.new_obs() instead. This alias will be removed in v0.4.0
 
     Sets the :attr:`.Var.observed` flag. If the observed variable is a
     random variable, i.e. if it has an associated probability distribution,
@@ -213,7 +213,7 @@ def Obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
         "Use lsl.Var.new_obs() instead. This class will be removed in v0.4.0",
         FutureWarning,
     )
-    return obs(value, distribution, name)
+    return Var.new_obs(value, distribution, name)
 
 
 def Param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> Var:
@@ -221,7 +221,7 @@ def Param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
     Declares a parameter variable.
 
     .. deprecated:: 0.2.6
-        Use lsl.param() instead. This alias will be removed in v0.4.0
+        Use lsl.Var.new_param() instead. This alias will be removed in v0.4.0
 
     Sets the :attr:`.Var.parameter` flag. If the parameter variable is a
     random variable, i.e. if it has an associated probability distribution,
@@ -242,4 +242,4 @@ def Param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
         "Use lsl.Var.new_param() instead. This class will be removed in v0.4.0",
         FutureWarning,
     )
-    return param(value, distribution, name)
+    return Var.new_param(value, distribution, name)

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -798,7 +798,7 @@ class GraphBuilder:
         We first set up the parameter var with its distribution:
 
         >>> prior = lsl.Dist(tfd.HalfCauchy, loc=0.0, scale=25.0)
-        >>> scale = lsl.param(1.0, prior, name="scale")
+        >>> scale = lsl.Var.new_param(1.0, prior, name="scale")
 
         Then we create a GraphBuilder and use the ``transform`` method to transform
         the ``scale`` variable.

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -720,7 +720,7 @@ class Calc(Node):
 
     A simple calculator node, taking the exponential value of an input parameter.
 
-    >>> log_scale = lsl.param(0.0, name="log_scale")
+    >>> log_scale = lsl.Var.new_param(0.0, name="log_scale")
     >>> scale = lsl.Calc(jnp.exp, log_scale)
     >>> print(scale.value)
     1.0
@@ -736,7 +736,7 @@ class Calc(Node):
 
     >>> def compute_variance(x):
     ...     return jnp.exp(x)**2
-    >>> log_scale = lsl.param(0.0, name="log_scale")
+    >>> log_scale = lsl.Var.new_param(0.0, name="log_scale")
     >>> variance = lsl.Calc(compute_variance, log_scale).update()
     >>> print(variance.value)
     1.0
@@ -885,7 +885,7 @@ class Dist(Node):
 
 
     >>> dist = lsl.Dist(tfd.Normal, loc=0.0, scale=1.0)
-    >>> y = lsl.obs(jnp.array([-0.5, 0.0, 0.5]), dist, name="y")
+    >>> y = lsl.Var.new_obs(jnp.array([-0.5, 0.0, 0.5]), dist, name="y")
     >>> print(y.log_prob)
     None
 
@@ -897,10 +897,10 @@ class Dist(Node):
     Now we define the same observation model, but include the location and scale
     as parameters:
 
-    >>> loc = lsl.param(0.0, name="loc")
-    >>> scale = lsl.param(1.0, name="scale")
+    >>> loc = lsl.Var.new_param(0.0, name="loc")
+    >>> scale = lsl.Var.new_param(1.0, name="scale")
     >>> dist = lsl.Dist(tfd.Normal, loc=loc, scale=scale)
-    >>> y = lsl.obs(jnp.array([-0.5, 0.0, 0.5]), dist, name="y").update()
+    >>> y = lsl.Var.new_obs(jnp.array([-0.5, 0.0, 0.5]), dist, name="y").update()
     >>> y.log_prob
     Array([-1.0439385, -0.9189385, -1.0439385], dtype=float32)
 
@@ -1579,7 +1579,7 @@ class Var:
         We first set up the parameter var with its distribution:
 
         >>> prior = lsl.Dist(tfd.HalfCauchy, loc=0.0, scale=25.0)
-        >>> scale = lsl.param(1.0, prior, name="scale")
+        >>> scale = lsl.Var.new_param(1.0, prior, name="scale")
 
         The we transform the variable to the log-scale:
 
@@ -2147,7 +2147,7 @@ def obs(value: Any | Calc, distribution: Dist | None = None, name: str = "") -> 
     model:
 
     >>> dist = lsl.Dist(tfd.Normal, loc=0.0, scale=1.0)
-    >>> y = lsl.obs(jnp.array([-0.5, 0.0, 0.5]), dist, name="y")
+    >>> y = lsl.Var.new_obs(jnp.array([-0.5, 0.0, 0.5]), dist, name="y")
     >>> y
     Var(name="y")
 
@@ -2220,7 +2220,7 @@ def param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
     A variance parameter with an inverse-gamma prior:
 
     >>> prior = lsl.Dist(tfd.InverseGamma, concentration=0.1, scale=0.1)
-    >>> variance = lsl.param(1.0, prior, name="variance")
+    >>> variance = lsl.Var.new_param(1.0, prior, name="variance")
     >>> variance
     Var(name="variance")
 
@@ -2228,7 +2228,7 @@ def param(value: Any | Calc, distribution: Dist | None = None, name: str = "") -
 
     >>> scale = lsl.Calc(jnp.sqrt, variance)
     >>> dist = lsl.Dist(tfd.Normal, loc=0.0, scale=scale)
-    >>> y = lsl.obs(jnp.array([-0.5, 0.0, 0.5]), dist, name="y")
+    >>> y = lsl.Var.new_obs(jnp.array([-0.5, 0.0, 0.5]), dist, name="y")
     >>> y
     Var(name="y")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ install_requires =
     blackjax>=1.0
     deprecated>=1.2
     dill>=0.3
-    jax>=0.4.1,<=0.4.31
-    jaxlib>=0.4.1,<=0.4.31
+    jax>=0.4.1
+    jaxlib>=0.4.1
     matplotlib>=3.5
     networkx>=2.6
     numpy>=1.22,!=1.24.0,<2.0

--- a/tests/distributions/test_mvn_degen.py
+++ b/tests/distributions/test_mvn_degen.py
@@ -1063,14 +1063,16 @@ def test_sampling() -> None:
         pen=lsl.Var(K),
     )
 
-    beta = lsl.param(jnp.zeros(5), mvnd, name="beta")
+    beta = lsl.Var.new_param(jnp.zeros(5), mvnd, name="beta")
 
     knots = _create_equidistant_knots(x, order=4, internal_k=4)
     basis_mat = BSpline.design_matrix(x, knots, 3).toarray()
-    X = lsl.obs(basis_mat[:, 1:])
+    X = lsl.Var.new_obs(basis_mat[:, 1:])
 
     smooth = lsl.Smooth(X, beta)
-    Y = lsl.obs(y, distribution=lsl.Dist(tfd.Normal, loc=smooth, scale=lsl.Var(1.0)))
+    Y = lsl.Var.new_obs(
+        y, distribution=lsl.Dist(tfd.Normal, loc=smooth, scale=lsl.Var(1.0))
+    )
     model = lsl.GraphBuilder().add(Y).build_model()
 
     builder = gs.EngineBuilder(1337, 1)

--- a/tests/goose/test_optim.py
+++ b/tests/goose/test_optim.py
@@ -29,14 +29,14 @@ ols_coef = np.linalg.inv(xs.T @ xs) @ xs.T @ ys
 
 
 def setup_model(ys: Array, xs: Array) -> lsl.Model:
-    x = lsl.obs(xs, name="x")
-    coef = lsl.param(jnp.zeros(2), name="coef")
+    x = lsl.Var.new_obs(xs, name="x")
+    coef = lsl.Var.new_param(jnp.zeros(2), name="coef")
     mu = lsl.Var(lsl.Calc(jnp.dot, x, coef), name="mu")
     log_sigma = lsl.Var(2.0, name="log_sigma")
     sigma = lsl.Var(lsl.Calc(jnp.exp, log_sigma), name="sigma")
 
     ydist = lsl.Dist(tfd.Normal, loc=mu, scale=sigma)
-    y = lsl.obs(ys, ydist, name="y")
+    y = lsl.Var.new_obs(ys, ydist, name="y")
 
     gb = lsl.GraphBuilder().add(y)
     model = gb.build_model()
@@ -148,14 +148,14 @@ class TestOptim:
 
 class TestLogProbDecompositionValidation:
     def test_const_priors(self):
-        x = lsl.obs(xs, name="x")
-        coef = lsl.param(jnp.zeros(2), name="coef")
+        x = lsl.Var.new_obs(xs, name="x")
+        coef = lsl.Var.new_param(jnp.zeros(2), name="coef")
         mu = lsl.Var(lsl.Calc(jnp.dot, x, coef), name="mu")
         log_sigma = lsl.Var(2.0, name="log_sigma")
         sigma = lsl.Var(lsl.Calc(jnp.exp, log_sigma), name="sigma")
 
         ydist = lsl.Dist(tfd.Normal, loc=mu, scale=sigma)
-        y = lsl.obs(ys, ydist, name="y")
+        y = lsl.Var.new_obs(ys, ydist, name="y")
 
         gb = lsl.GraphBuilder().add(y)
         model = gb.build_model()
@@ -166,8 +166,8 @@ class TestLogProbDecompositionValidation:
         assert _validate_log_prob_decomposition(interface, position, model.state)
 
     def test_prior(self):
-        x = lsl.obs(xs, name="x")
-        coef = lsl.param(
+        x = lsl.Var.new_obs(xs, name="x")
+        coef = lsl.Var.new_param(
             jnp.zeros(2),
             distribution=lsl.Dist(tfd.Normal, loc=0.0, scale=10.0),
             name="coef",
@@ -177,7 +177,7 @@ class TestLogProbDecompositionValidation:
         sigma = lsl.Var(lsl.Calc(jnp.exp, log_sigma), name="sigma")
 
         ydist = lsl.Dist(tfd.Normal, loc=mu, scale=sigma)
-        y = lsl.obs(ys, ydist, name="y")
+        y = lsl.Var.new_obs(ys, ydist, name="y")
 
         gb = lsl.GraphBuilder().add(y)
         model = gb.build_model()
@@ -188,7 +188,7 @@ class TestLogProbDecompositionValidation:
         assert _validate_log_prob_decomposition(interface, position, model.state)
 
     def test_prior_but_not_param(self):
-        x = lsl.obs(xs, name="x")
+        x = lsl.Var.new_obs(xs, name="x")
         coef = lsl.Var(
             jnp.zeros(2),
             distribution=lsl.Dist(tfd.Normal, loc=0.0, scale=10.0),
@@ -199,7 +199,7 @@ class TestLogProbDecompositionValidation:
         sigma = lsl.Var(lsl.Calc(jnp.exp, log_sigma), name="sigma")
 
         ydist = lsl.Dist(tfd.Normal, loc=mu, scale=sigma)
-        y = lsl.obs(ys, ydist, name="y")
+        y = lsl.Var.new_obs(ys, ydist, name="y")
 
         gb = lsl.GraphBuilder().add(y)
         model = gb.build_model()
@@ -211,8 +211,8 @@ class TestLogProbDecompositionValidation:
             _validate_log_prob_decomposition(interface, position, model.state)
 
     def test_not_obs(self):
-        x = lsl.obs(xs, name="x")
-        coef = lsl.param(
+        x = lsl.Var.new_obs(xs, name="x")
+        coef = lsl.Var.new_param(
             jnp.zeros(2),
             distribution=lsl.Dist(tfd.Normal, loc=0.0, scale=10.0),
             name="coef",

--- a/tests/model/test_legacy.py
+++ b/tests/model/test_legacy.py
@@ -18,7 +18,7 @@ from liesel.model.legacy import (
     Smooth,
     SmoothingParam,
 )
-from liesel.model.nodes import Dist, Value, Var, param
+from liesel.model.nodes import Dist, Value, Var
 
 
 def test_design_matrix() -> None:
@@ -32,8 +32,8 @@ def test_hyperparameter() -> None:
 
 
 def test_parameter() -> None:
-    loc = param(0.0, name="loc")
-    scale = param(1.0, name="scale")
+    loc = Var.new_param(0.0, name="loc")
+    scale = Var.new_param(1.0, name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     x = Parameter(value=1.0, distribution=dist, name="x")
     x.update()
@@ -45,8 +45,8 @@ def test_parameter() -> None:
 def test_regression_coef() -> None:
     arr = jnp.array([1.0, 3.0, 2.3])
 
-    loc = param(0.0, name="loc")
-    scale = param(1.0, name="scale")
+    loc = Var.new_param(0.0, name="loc")
+    scale = Var.new_param(1.0, name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     beta = RegressionCoef(value=arr, distribution=dist, name="beta")
     beta.update()
@@ -58,8 +58,8 @@ def test_regression_coef() -> None:
 def test_response() -> None:
     arr = jnp.array([1.0, 0.0, 2.0])
 
-    loc = param(0.0, name="loc")
-    scale = param(1.0, name="scale")
+    loc = Var.new_param(0.0, name="loc")
+    scale = Var.new_param(1.0, name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     y = Response(value=arr, distribution=dist, name="y")
     y.update()
@@ -69,8 +69,8 @@ def test_response() -> None:
 
 
 def test_smoothing_param() -> None:
-    loc = param(0.0, name="loc")
-    scale = param(1.0, name="scale")
+    loc = Var.new_param(0.0, name="loc")
+    scale = Var.new_param(1.0, name="scale")
     dist = Dist(tfd.Normal, loc, scale)
     tau2 = SmoothingParam(value=1.0, distribution=dist, name="tau2")
     tau2.update()

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -11,7 +11,7 @@ import pytest
 import tensorflow_probability.substrates.jax.distributions as tfd
 
 from liesel.model.model import GraphBuilder, Model, save_model
-from liesel.model.nodes import Calc, Dist, Group, TransientNode, Value, Var, obs, param
+from liesel.model.nodes import Calc, Dist, Group, TransientNode, Value, Var
 
 
 @pytest.fixture
@@ -35,7 +35,7 @@ def beta() -> Generator:
     beta_prior_scale = Var(100.0, name="beta_scale")
     beta_prior = Dist(tfd.Normal, loc=beta_prior_loc, scale=beta_prior_scale)
 
-    beta_hat = param(
+    beta_hat = Var.new_param(
         value=jnp.array([0.0, 0.0]), distribution=beta_prior, name="beta_hat"
     )
     yield beta_hat
@@ -52,7 +52,7 @@ def sigma() -> Generator:
         scale=sigma_prior_scale,
     )
 
-    sigma_hat = param(
+    sigma_hat = Var.new_param(
         value=10.0,
         distribution=sigma_prior,
         name="sigma_hat",
@@ -64,13 +64,13 @@ def sigma() -> Generator:
 @pytest.fixture
 def y_var(data, beta, sigma) -> Generator:
     x, y = data
-    x_var = obs(x, name="X")
+    x_var = Var.new_obs(x, name="X")
 
     mu_calc = Calc(lambda X, beta: X @ beta, x_var, beta)
     mu_hat = Var(mu_calc, name="mu")
 
     likelihood = Dist(tfd.Normal, loc=mu_hat, scale=sigma)
-    y_var = obs(value=y, distribution=likelihood, name="y_var")
+    y_var = Var.new_obs(value=y, distribution=likelihood, name="y_var")
 
     Group("loc", X=x_var, beta=beta)
     Group("scale", scale=sigma)


### PR DESCRIPTION
This PR fixes most of the test warnings caused by parts of the codebase using the deprecated functions `lsl.obs` and `lsl.param`. Adresses most of #227

Three warnings remain. They seem to be emitted by the pymc interface tests. I had a very quick go at fixing the `dtypes` warning by switching `pytensor` to `float32`, but that caused one of the tests to fail. For the moment, I decided to not pursue this further.

```
============================================================== warnings summary ==============================================================
site-packages/pytensor/configdefaults.py:375
site-packages/pytensor/configdefaults.py:375: DeprecationWarning: Use shutil.which instead of find_executable
    newp = find_executable(param)

tests/experimental/test_pymc.py::test_simple2
tests/experimental/test_pymc.py::test_simple2
/site-packages/jax/_src/numpy/array_methods.py:118: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/jax-ml/jax#current-gotchas for more.
    return lax_numpy.astype(self, dtype, copy=copy, device=device)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================== 417 passed, 16 skipped, 5 xfailed, 3 warnings in 76.63s (0:01:16) **======================================**
```