### PR TITLE
Allow transformation of weak vars

### DIFF
--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -756,8 +756,9 @@ class Calc(Node):
     ):
         super().__init__(*inputs, **kwinputs, _name=_name, _needs_seed=_needs_seed)
         self._function = function
+        self.update_on_init = update_on_init
 
-        if update_on_init:
+        if self.update_on_init:
             try:
                 self.update()
             except Exception as e:
@@ -1971,11 +1972,43 @@ def _transform_var_with_bijector_instance(var: Var, bijector_inst: jb.Bijector) 
 
     transformed_dist.per_obs = var.dist_node.per_obs
 
-    transformed_var = Var(
-        bijector_inv.forward(var.value),
-        transformed_dist,
-        name=f"{var.name}_transformed",
-    )
+    if var.weak:
+        try:
+            value_function = var.value_node.function  # type: ignore
+        except AttributeError as e:
+            raise AttributeError(
+                "Trying to transform a weak variable without calculator node."
+            ) from e
+
+        def forward(*args, **kwargs):
+            return bijector_inv.forward(value_function(*args, **kwargs))
+
+        value_inputs = var.value_node.inputs
+        value_kwinputs = var.value_node.kwinputs
+        value_node_needs_seed = var.value_node.needs_seed
+        try:
+            value_node_upadte_on_init = var.value_node.update_on_init  # type: ignore
+        except AttributeError as e:
+            raise e
+
+        transformed_var = Var(
+            Calc(
+                forward,
+                *value_inputs,
+                _name="",
+                _needs_seed=value_node_needs_seed,
+                update_on_init=value_node_upadte_on_init,
+                **value_kwinputs,
+            ),
+            transformed_dist,
+            name=f"{var.name}_transformed",
+        )
+    else:
+        transformed_var = Var(
+            bijector_inv.forward(var.value),
+            transformed_dist,
+            name=f"{var.name}_transformed",
+        )
 
     var.value_node = Calc(bijector_inst.forward, transformed_var)
     return transformed_var
@@ -2026,11 +2059,43 @@ def _transform_var_with_bijector_class(
 
     bijector_inv = dist_node_transformed.init_dist().bijector
 
-    transformed_var = Var(
-        bijector_inv.forward(var.value),
-        dist_node_transformed,
-        name=f"{var.name}_transformed",
-    )
+    if var.weak:
+        try:
+            value_function = var.value_node.function  # type: ignore
+        except AttributeError as e:
+            raise AttributeError(
+                "Trying to transform a weak variable without calculator node."
+            ) from e
+
+        def forward(*args, **kwargs):
+            return bijector_inv.forward(value_function(*args, **kwargs))
+
+        value_inputs = var.value_node.inputs
+        value_kwinputs = var.value_node.kwinputs
+        value_node_needs_seed = var.value_node.needs_seed
+        try:
+            value_node_upadte_on_init = var.value_node.update_on_init  # type: ignore
+        except AttributeError as e:
+            raise e
+
+        transformed_var = Var(
+            Calc(
+                forward,
+                *value_inputs,
+                _name="",
+                _needs_seed=value_node_needs_seed,
+                update_on_init=value_node_upadte_on_init,
+                **value_kwinputs,
+            ),
+            dist_node_transformed,
+            name=f"{var.name}_transformed",
+        )
+    else:
+        transformed_var = Var(
+            bijector_inv.forward(var.value),
+            dist_node_transformed,
+            name=f"{var.name}_transformed",
+        )
 
     def bijector_fn(value, dist_inputs, bijector_inputs):
         bijector = transform_dist(dist_inputs, bijector_inputs).bijector

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -556,6 +556,40 @@ class TestVarConstructors:
 
 
 class TestVarTransform:
+    def test_transform_weak_var_with_bijector_instance(self) -> None:
+        tau = lnodes.Var.new_param(10.0, name="tau")
+        tau_sqrt = lnodes.Var.new_calc(jnp.sqrt, tau)
+        log_tau_sqrt = tau_sqrt.transform(tfp.bijectors.Exp())
+
+        assert tau.value == pytest.approx(10.0)
+        assert tau_sqrt.value == pytest.approx(jnp.sqrt(10.0))
+        assert log_tau_sqrt.value == pytest.approx(jnp.log(jnp.sqrt(10.0)))
+
+        assert tau.strong
+        assert tau_sqrt.weak
+        assert log_tau_sqrt.weak
+        assert tau.parameter
+        assert not log_tau_sqrt.parameter
+        assert not tau_sqrt.parameter
+
+    def test_transform_weak_var_with_bijector_class(self) -> None:
+        tau = lnodes.Var.new_param(10.0, name="tau")
+        tau_sqrt = lnodes.Var.new_calc(jnp.sqrt, tau)
+
+        scale = lnodes.Var.new_param(2.0, name="bijector_scale")
+        scaled_tau_sqrt = tau_sqrt.transform(tfp.bijectors.Scale, scale=scale)
+
+        assert tau.value == pytest.approx(10.0)
+        assert tau_sqrt.value == pytest.approx(jnp.sqrt(10.0))
+        assert scaled_tau_sqrt.value == pytest.approx(jnp.sqrt(10.0) / 2)
+
+        assert tau.strong
+        assert tau_sqrt.weak
+        assert scaled_tau_sqrt.weak
+        assert tau.parameter
+        assert not scaled_tau_sqrt.parameter
+        assert not tau_sqrt.parameter
+
     def test_transform_without_dist_with_bijector_instance(self) -> None:
         tau = lnodes.Var.new_param(10.0, name="tau")
         log_tau = tau.transform(tfp.bijectors.Exp())


### PR DESCRIPTION
So far, we did not allow transformation of weak vars in `Var.transform`. I have a usecase for that right now, and I don't think anything really speaks against allowing it. This PR makes two small changes that enable the functionality.

If you transform a weak var, it gets inserted in between the old value node and the transformed variable:


```python
import liesel.model as lsl
import jax.numpy as jnp
import tensorflow_probability.substrates.jax.bijectors as tfb

tau = lsl.Var.new_param(10.0, name="tau")
tau_sqrt = lsl.Var.new_calc(jnp.sqrt, tau, name="tau_sqrt")
log_tau_sqrt = tau_sqrt.transform(tfb.Exp())
model = lsl.Model([tau_sqrt])
lsl.plot_vars(model)
```

![image](https://github.com/user-attachments/assets/6bc7c9b0-7719-415d-b13e-9ea980fb3376)
