### PR TITLE
Allow distributions in Var.new_calc

### DIFF
--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1333,6 +1333,7 @@ class Var:
         cls,
         function: Callable[..., Any],
         *inputs: Any,
+        distribution: Dist | None = None,
         name: str = "",
         _needs_seed: bool = False,
         update_on_init: bool = True,
@@ -1360,6 +1361,8 @@ class Var:
             will be converted to :class:`.Value` nodes. The values of these inputs \
             will be passed to the wrapped function in the same order they are entered \
             here.
+        distribution
+            The probability distribution of the variable.
         _name
             The name of the node. If you do not specify a name, a unique name will be \
             automatically generated upon initialization of a :class:`.Model`.
@@ -1426,7 +1429,7 @@ class Var:
             update_on_init=update_on_init,
             **kwinputs,
         )
-        var = cls(calc, name=name)
+        var = cls(calc, distribution=distribution, name=name)
         return var
 
     @classmethod

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1363,7 +1363,7 @@ class Var:
             here.
         distribution
             The probability distribution of the variable.
-        _name
+        name
             The name of the node. If you do not specify a name, a unique name will be \
             automatically generated upon initialization of a :class:`.Model`.
         _needs_seed

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -549,6 +549,20 @@ class TestVarConstructors:
         assert loc.value == pytest.approx(2.0)
         assert loc.weak
 
+    def test_new_calc_with_dist(self):
+        loc = lnodes.Var.new_calc(
+            lambda x: x + 1.0,
+            distribution=lnodes.Dist(tfp.distributions.Normal, loc=0.0, scale=1.0),
+            x=1.0,
+            name="loc",
+        )
+        loc.update()
+        assert isinstance(loc, lnodes.Var)
+        assert loc.value == pytest.approx(2.0)
+        assert loc.weak
+        assert loc.dist_node is not None
+        assert loc.log_prob is not None
+
     def test_new_const(self):
         loc = lnodes.Var.new_value(1.0, name="loc")
         assert isinstance(loc, lnodes.Var)


### PR DESCRIPTION
Small PR that allows users to specify a distribution in `Var.new_calc`. I originally thought this was unnecessary, but there are some edge cases when it might be useful. 

For example, in a copula model, you might have two strong variables with distributions representing the margins, and a weak calculator variable on the u-level after probability transformation. This weak caculator may receive the copula distribution to complete the setup.