### PR TITLE
Introduce argument 'mcmc_kernel' to lsl.Var

### DIFF
--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -11,7 +11,7 @@ from collections import Counter
 from collections.abc import Iterable
 from copy import deepcopy
 from types import MappingProxyType
-from typing import IO, Any, Literal, TypeVar
+from typing import IO, TYPE_CHECKING, Any, Literal, TypeVar
 
 import dill
 import jax
@@ -39,6 +39,9 @@ from .nodes import (
     is_bijector_class,
 )
 from .viz import plot_nodes, plot_vars
+
+if TYPE_CHECKING:
+    from ..goose.kernel import Kernel
 
 __all__ = ["GraphBuilder", "Model", "load_model", "save_model"]
 
@@ -1532,6 +1535,12 @@ class Model:
             height=height,
             prog=prog,
         )
+
+    def mcmc_kernels(self) -> dict[str, Kernel]:
+        """Returns dictionary of variable names and corresponding MCMC kernels."""
+        return {
+            k: v.mcmc_kernel for k, v in self.vars.items() if v.mcmc_kernel is not None
+        }
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1722,6 +1722,10 @@ class Var:
         self.parameter = False
         self.dist_node = None
 
+        if self._mcmc_kernel is not None:
+            logger.warning(f"Removing MCMC kernel {self._mcmc_kernel} from {self}.")
+            self._mcmc_kernel = None
+
         return tvar
 
     @in_model_method

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1502,7 +1502,7 @@ class Var:
     def mcmc_kernel(self) -> Kernel | None:
         """MCMC kernel for this variable."""
         if isinstance(self._mcmc_kernel, type):
-            return self._mcmc_kernel([self.name])  # type: ignore
+            self._mcmc_kernel = self._mcmc_kernel([self.name])  # type: ignore
 
         return self._mcmc_kernel
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1502,7 +1502,16 @@ class Var:
         return self._mcmc_kernel
 
     @mcmc_kernel.setter
-    def mcmc_kernel(self, value: Kernel):
+    def mcmc_kernel(self, value: type[Kernel] | Kernel | None):
+        if value is None:
+            self._mcmc_kernel = value
+            return
+
+        if self.weak:
+            raise ValueError(f"{self} is weak, cannot set MCMC kernel.")
+        if self.observed:
+            raise ValueError(f"{self} is observed, cannot set MCMC kernel.")
+
         self._mcmc_kernel = value
 
     def all_input_nodes(self) -> tuple[Node, ...]:

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1679,8 +1679,6 @@ class Var:
             tvar.parameter = self.parameter  # type: ignore
             self.parameter = False
 
-        elif self.dist_node is None:  # type: ignore
-            raise RuntimeError(f"{repr(self)} has no distribution")
         else:
             # avoid infinite recursion
             self.auto_transform = False

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1302,7 +1302,6 @@ class Var:
         value: Any,
         distribution: Dist | None = None,
         name: str = "",
-        mcmc_kernel: type[Kernel] | Kernel | None = None,
     ) -> Var:
         """
         Initializes a strong variable that holds observed data.
@@ -1320,10 +1319,6 @@ class Var:
         name
             The name of the variable. If you do not specify a name, a unique name will \
             be automatically generated upon initialization of a :class:`.Model`.
-        mcmc_kernel
-            A :class:`.goose.Kernel` instance or class for easy access via the \
-            :attr:`.mcmc_kernel` attribute and collection in the \
-            :meth:`~liesel.model.Model.mcmc_kernels` method.
 
         See Also
         --------
@@ -1349,7 +1344,7 @@ class Var:
         Var(name="")
 
         """
-        var = cls(value, distribution, name, mcmc_kernel=mcmc_kernel)
+        var = cls(value, distribution, name)
         var.observed = True
         return var
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1673,54 +1673,52 @@ class Var:
             )
             tvar.parameter = self.parameter  # type: ignore
             self.parameter = False
-            return tvar
 
         elif self.dist_node is None:
             tvar = _transform_var_without_dist_with_bijector_instance(self, bijector)
             tvar.parameter = self.parameter  # type: ignore
             self.parameter = False
-            return tvar
 
-        if self.dist_node is None:  # type: ignore
+        elif self.dist_node is None:  # type: ignore
             raise RuntimeError(f"{repr(self)} has no distribution")
-
-        # avoid infinite recursion
-        self.auto_transform = False
-
-        # use default event space bijector if bijector is None
-        use_default_bijector = bijector is None
-        if use_default_bijector:
-            dist_inst = self.dist_node.init_dist()
-            default_bijector = dist_inst.experimental_default_event_space_bijector
-
-        if use_default_bijector and default_bijector is None:
-            raise RuntimeError(
-                f"{self} has distribution without default event space bijector "
-                "and no bijector was given"
-            )
-
-        if is_bijector_class(bijector) or use_default_bijector:
-            tvar = _transform_var_with_bijector_class(
-                self, bijector, *bijector_args, **bijector_kwargs
-            )
-        elif isinstance(bijector, jb.Bijector):
-            if bijector_args or bijector_kwargs:
-                raise RuntimeError(
-                    "You passed a bijector instance and "
-                    "nonempty bijector arguments. You should either initialise your "
-                    "bijector directly with the arguments, or pass a bijector class "
-                    "instead. The first option is preferred, if the bijector arguments"
-                    "are constant."
-                )
-            tvar = _transform_var_with_bijector_instance(self, bijector)
         else:
-            raise TypeError(
-                f"Argument {bijector=} is of invalid type {type(bijector)}."
-            )
+            # avoid infinite recursion
+            self.auto_transform = False
 
-        tvar.parameter = self.parameter  # type: ignore
-        self.parameter = False
-        self.dist_node = None
+            # use default event space bijector if bijector is None
+            use_default_bijector = bijector is None
+            if use_default_bijector:
+                dist_inst = self.dist_node.init_dist()
+                default_bijector = dist_inst.experimental_default_event_space_bijector
+
+            if use_default_bijector and default_bijector is None:
+                raise RuntimeError(
+                    f"{self} has distribution without default event space bijector "
+                    "and no bijector was given"
+                )
+
+            if is_bijector_class(bijector) or use_default_bijector:
+                tvar = _transform_var_with_bijector_class(
+                    self, bijector, *bijector_args, **bijector_kwargs
+                )
+            elif isinstance(bijector, jb.Bijector):
+                if bijector_args or bijector_kwargs:
+                    raise RuntimeError(
+                        "You passed a bijector instance and nonempty bijector"
+                        " arguments. You should either initialise your bijector"
+                        " directly with the arguments, or pass a bijector class"
+                        " instead. The first option is preferred, if the bijector"
+                        " argumentsare constant."
+                    )
+                tvar = _transform_var_with_bijector_instance(self, bijector)
+            else:
+                raise TypeError(
+                    f"Argument {bijector=} is of invalid type {type(bijector)}."
+                )
+
+            tvar.parameter = self.parameter  # type: ignore
+            self.parameter = False
+            self.dist_node = None
 
         if self._mcmc_kernel is not None:
             logger.warning(f"Removing MCMC kernel {self._mcmc_kernel} from {self}.")

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -10,6 +10,7 @@ import jax.random as rnd
 import pytest
 import tensorflow_probability.substrates.jax.distributions as tfd
 
+import liesel.goose as gs
 from liesel.model.model import GraphBuilder, Model, save_model
 from liesel.model.nodes import Calc, Dist, Group, TransientNode, Value, Var
 
@@ -350,6 +351,35 @@ class TestModel:
 
         assert "x_transformed" in new_model.vars
         assert new_model.vars["x_transformed"].value == pytest.approx(0.54132485)
+
+    def test_mcmc_kernels(self):
+        mu = Var(
+            value=0.0,
+            distribution=Dist(tfd.Normal, loc=0.0, scale=1.0),
+            name="mu",
+            mcmc_kernel=gs.NUTSKernel,
+        )
+
+        model = Model([mu])
+
+        kernels = model.mcmc_kernels()
+
+        assert len(kernels) == 1
+        assert isinstance(kernels["mu"], gs.NUTSKernel)
+
+        mu = Var(
+            value=0.0,
+            distribution=Dist(tfd.Normal, loc=0.0, scale=1.0),
+            name="mu",
+            mcmc_kernel=gs.NUTSKernel(["mu"]),
+        )
+
+        model = Model([mu])
+
+        kernels = model.mcmc_kernels()
+
+        assert len(kernels) == 1
+        assert isinstance(kernels["mu"], gs.NUTSKernel)
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
## Motivation

Often, when I build a liesel model and a corresponding MCMC algorithm, I find that, when it is time to define my MCMC kernels, I cannot remember all of the names of the variables I want to sample. As a result, I jump back and forth between the `gs.EngineBuilder` code, and the model definition code, looking up and copy-pasting variable names for kernel initialization. 

Also, when I add or remove a variable, I always have to update two places in the code: Model definition, and MCMC algorithm.

This feels like a lot of empty busy-work. I would like more convenience.

## This PR

This is a small PR that adds an init argument and attribute `mcmc_kernel` to lsl.Var and a method `mcmc_kernels` to lsl.Model. 

- The argument allows you to pass a `gs.Kernel` class or instance, which will afterwards be available in the `Var.mcmc_kernel` property. 
    - The property always returns a kernel *instance*. If a class object was passed as the argument, the class will be instantiated as `Kernel([self.name])`, i.e. with the variable name as the sole position key and default arguments otherwise.
- The `Model.mcmc_kernels` method returns a dictionary of all kernels found at variables in the model.

The purpose is convenience: When defining a Liesel model, I can specify the desired MCMC kernel right where I define the variable. This makes it easy to in- or exclude individual variables from the model. 

## Pattern example

```python
mu = Var(
    value=0.0,
    distribution=Dist(tfd.Normal, loc=0.0, scale=1.0),
    name="mu",
    mcmc_kernel=gs.NUTSKernel,
)

sigma = Var(
    value=1.0,
    distribution=Dist(tfd.InverseGamma, concentration=0.01, scale=0.01),
    name="sigma",
    mcmc_kernel=gs.HMCKernel(["sigma"], da_target_accept=0.6)
)

model = Model([mu])

eb = gs.EngineBuilder()

for kernel in model.mcmc_kernels().values():
    eb.add_kernel()
```

## Connection between model and estimation

This PR introduces a crack into the strict separation of model and estimation that we otherwise have in the Liesel library. However, I think that the gain in user-friendlyness is worth it.

Something similar was long ago hinted at here: 

- #42

I think this PR may be considered as closing that issue.

## Transformed variables

If a variable with an mcmc kernel is transformed, the kernel is removed without replacement. Users are warned. The intended pattern for adding mcmc kernels to transformed variables is:

```python
a = lsl.Var(0.0, name="a")
b = a.transform(tfb.Exp()) # If any kernel was defined, it will be removed here
b.mcmc_kernel = gs.NUTSKernel
```