### PR TITLE
Add Model.parameters and Model.observed properties

### DIFF
--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -1431,6 +1431,18 @@ class Model:
         """A mapping of the model variables with their names as keys."""
         return MappingProxyType(self._vars)
 
+    @property
+    def parameters(self) -> MappingProxyType[str, Var]:
+        """A mapping of the model parameters with their names as keys."""
+        params = {k: v for k, v in self._vars.items() if v.parameter}
+        return MappingProxyType(params)
+
+    @property
+    def observed(self) -> MappingProxyType[str, Var]:
+        """A mapping of the observed model variables with their names as keys."""
+        params = {k: v for k, v in self._vars.items() if v.observed}
+        return MappingProxyType(params)
+
     def __repr__(self) -> str:
         brackets = f"({len(self._nodes)} nodes, {len(self._vars)} vars)"
         return type(self).__name__ + brackets

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -1440,8 +1440,8 @@ class Model:
     @property
     def observed(self) -> MappingProxyType[str, Var]:
         """A mapping of the observed model variables with their names as keys."""
-        params = {k: v for k, v in self._vars.items() if v.observed}
-        return MappingProxyType(params)
+        observed = {k: v for k, v in self._vars.items() if v.observed}
+        return MappingProxyType(observed)
 
     def __repr__(self) -> str:
         brackets = f"({len(self._nodes)} nodes, {len(self._vars)} vars)"

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -190,6 +190,24 @@ class TestModel:
 
         assert model.log_prob == pytest.approx(model.log_lik + model.log_prior)
 
+    def test_parameters(self, model: Model) -> None:
+        assert len(model.parameters) == 2
+        assert "sigma_hat" in model.parameters
+        assert "beta_hat" in model.parameters
+
+        parameters_log_prob = [var.log_prob.sum() for var in model.parameters.values()]
+        assert sum(parameters_log_prob) == pytest.approx(model.log_prior)
+
+    def test_observed(self, model: Model) -> None:
+        assert len(model.observed) == 2
+        assert "y_var" in model.observed
+        assert "X" in model.observed
+
+        observed_log_prob = [
+            jnp.atleast_1d(var.log_prob).sum() for var in model.observed.values()
+        ]
+        assert sum(observed_log_prob) == pytest.approx(model.log_lik)
+
     def test_var_graph(self, model: Model) -> None:
         """
         Verifies that all model vars are present in the graph and vice versa.


### PR DESCRIPTION
This PR adds two small convenience properties to the `lsl.Model` class for direct access to parameter and observed variables.