### PR TITLE
Add Model.predict and Var.predict

### DIFF
--- a/liesel/goose/interface.py
+++ b/liesel/goose/interface.py
@@ -280,16 +280,7 @@ class LieselInterface:
         model_state
             A dictionary of node names and their corresponding :class:`.NodeState`.
         """
-        position = {}
-
-        for key in position_keys:
-            try:
-                position[key] = model_state[key].value
-            except KeyError:
-                node_key = self._model.vars[key].value_node.name
-                position[key] = model_state[node_key].value
-
-        return Position(position)
+        return self._model.extract_position(position_keys, model_state)  # type: ignore
 
     def update_state(self, position: Position, model_state: ModelState) -> ModelState:
         """
@@ -309,23 +300,7 @@ class LieselInterface:
         ``position``. If you supply a ``model_state`` with outdated nodes, these nodes
         and their outputs will not be updated.
         """
-
-        # sets all outdated flags in the model state to false
-        # this is required to make the function jittable
-
-        self._model.state = model_state
-
-        for node in self._model.nodes.values():
-            node._outdated = False
-
-        for key, value in position.items():
-            try:
-                self._model.nodes[key].value = value  # type: ignore  # data node
-            except KeyError:
-                self._model.vars[key].value = value
-
-        self._model.update()
-        return self._model.state
+        return self._model.update_state(position, model_state)
 
     def log_prob(self, model_state: ModelState) -> float:
         """

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -1234,6 +1234,29 @@ class Model:
         subgraph = self.var_graph.subgraph(nodes_to_include)
         return subgraph
 
+    def parental_submodel(self, *of: Var | Node) -> Model:
+        """
+        Returns a new model that consists only of the given variables and nodes and \
+        their parent variables and nodes. The new model contains copies of these \
+        variables and nodes.
+        """
+        nodes_to_include = set()
+
+        for node in of:
+            if isinstance(node, Var):
+                nodes_to_include.update(nx.ancestors(self.var_graph, node))
+            else:
+                nodes_to_include.update(nx.ancestors(self.node_graph, node))
+            nodes_to_include.add(node)
+
+        copy_of_nodes_to_include = deepcopy(nodes_to_include)
+
+        for node in copy_of_nodes_to_include:
+            if hasattr(node, "_unset_model"):
+                node._unset_model()
+
+        return Model(list(copy_of_nodes_to_include))
+
     @property
     def log_lik(self) -> Array:
         """

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -8,7 +8,7 @@ import logging
 import re
 import warnings
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from types import MappingProxyType
 from typing import IO, Any, Literal, TypeVar
@@ -1555,6 +1555,34 @@ class Model:
             height=height,
             prog=prog,
         )
+
+    def extract_position(
+        self,
+        position_keys: Sequence[str],
+        model_state: dict[str, NodeState] | None = None,
+    ) -> dict[str, Array]:
+        """
+        Extracts a position from a model state.
+
+        Parameters
+        ----------
+        position_keys
+            An iterable of variable or node names.
+        model_state
+            A dictionary of node names and their corresponding :class:`.NodeState`. \
+            If ``None`` (default), the model's current state is used.
+        """
+        model_state = model_state if model_state is not None else self.state
+        position = {}
+
+        for key in position_keys:
+            try:
+                position[key] = model_state[key].value
+            except KeyError:
+                node_key = self.vars[key].value_node.name
+                position[key] = model_state[node_key].value
+
+        return position
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -2087,6 +2087,35 @@ class Var:
             prog=prog,
         )
 
+    def predict(
+        self,
+        samples: dict[str, Array],
+        newdata: dict[str, Array] | None = None,
+    ) -> Array:
+        """
+        Returns an array of predictions for this variable.
+
+        Parameters
+        ----------
+        samples
+            Dictionary of samples at which to evaluate predictions. All values of the \
+            dictionary are assumed to have two leading dimensions corresponding to \
+            ``(nchains, niteration)``.
+        newdata
+            Dictionary of new data at which to evaluate predictions. The keys should \
+            correspond to variable or node names in the model whose values should be \
+            set to the given values before evaluating predictions.
+        """
+
+        if not self.model:
+            raise ValueError(
+                f"For predictions, a model is required, but {self.model=}."
+            )
+
+        submodel = self.model.parental_submodel(self)
+        pred = submodel.predict(samples=samples, predict=[self.name], newdata=newdata)
+        return pred[self.name]
+
     def plot_nodes(
         self,
         show: bool = True,

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -2087,6 +2087,7 @@ class Var:
             prog=prog,
         )
 
+    @in_model_method
     def predict(
         self,
         samples: dict[str, Array],
@@ -2107,12 +2108,7 @@ class Var:
             set to the given values before evaluating predictions.
         """
 
-        if not self.model:
-            raise ValueError(
-                f"For predictions, a model is required, but {self.model=}."
-            )
-
-        submodel = self.model.parental_submodel(self)
+        submodel = self.model.parental_submodel(self)  # type: ignore
         pred = submodel.predict(samples=samples, predict=[self.name], newdata=newdata)
         return pred[self.name]
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -351,6 +351,10 @@ class TestModel:
         assert "x_transformed" in new_model.vars
         assert new_model.vars["x_transformed"].value == pytest.approx(0.54132485)
 
+    def test_extract_position(self, model) -> None:
+        pos = model.extract_position(["z"])
+        assert pos["z"] == pytest.approx(model.nodes["z"].value)
+
 
 @pytest.mark.xfail
 class TestUserDefinedModelNodes:

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -355,6 +355,34 @@ class TestModel:
         pos = model.extract_position(["z"])
         assert pos["z"] == pytest.approx(model.nodes["z"].value)
 
+    def test_update_state(self, model) -> None:
+        pos = {"z": 3.0}
+        state = model.update_state(pos, inplace=False)
+        assert model.extract_position(["z"], model_state=state)["z"] == pytest.approx(
+            3.0
+        )
+        assert model.nodes["z"].value != pytest.approx(3.0)
+
+        # updating the state from above
+        pos = {"sigma_hat": 20.0}
+        state = model.update_state(pos, inplace=False, model_state=state)
+
+        # extracted position from updated state should contain the updated values
+        extracted_pos = model.extract_position(["z", "sigma_hat"], model_state=state)
+        assert extracted_pos["z"] == pytest.approx(3.0)
+        assert extracted_pos["sigma_hat"] == pytest.approx(20.0)
+
+        # original model state should be unchanged
+        assert model.nodes["z"] != pytest.approx(3.0)
+        assert model.vars["sigma_hat"].value != pytest.approx(20.0)
+
+        pos = {"z": 3.0}
+        state = model.update_state(pos, inplace=True)
+        assert model.extract_position(["z"], model_state=state)["z"] == pytest.approx(
+            3.0
+        )
+        assert model.nodes["z"].value == pytest.approx(3.0)
+
 
 @pytest.mark.xfail
 class TestUserDefinedModelNodes:

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -402,6 +402,24 @@ class TestPredictions:
         assert pred["mu"].shape == (4, 3, 500)
         assert len(pred) == len(model.vars)
 
+    def test_predict_with_unused_samples(self, model) -> None:
+        samples = {
+            "sigma_hat": tfd.Uniform().sample((4, 3), rnd.PRNGKey(6)),
+            "beta_hat": tfd.Uniform().sample((4, 3, 2), rnd.PRNGKey(6)),
+            "unused": tfd.Uniform().sample((4, 3, 2), rnd.PRNGKey(6)),
+        }
+
+        # manual prediction
+        manual_pred = jnp.einsum(
+            "nk,...k->...n", model.vars["X"].value, samples["beta_hat"]
+        )
+
+        # predictions at current values for all vars
+        pred = model.predict(samples=samples)
+        assert jnp.allclose(pred["mu"], manual_pred)
+        assert pred["mu"].shape == (4, 3, 500)
+        assert len(pred) == len(model.vars)
+
     def test_predict_for_specific_var(self, model) -> None:
         samples = {
             "sigma_hat": tfd.Uniform().sample((4, 3), rnd.PRNGKey(6)),

--- a/tests/model/test_var.py
+++ b/tests/model/test_var.py
@@ -2,9 +2,8 @@ import pickle
 import typing
 import warnings
 
-
-import jax
 import dill
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -804,7 +803,7 @@ class TestVarTransform:
         assert len(model2.vars) == len(model.vars)
         assert len(model2.nodes) == len(model.nodes)
         assert model2.log_prob == pytest.approx(model.log_prob)
-        
+
 
 class TestVarPredictions:
     def test_predict(self) -> None:
@@ -814,16 +813,16 @@ class TestVarPredictions:
         e = jax.random.normal(jax.random.PRNGKey(2), (n,))
         y = x * b + e
 
-        xvar = lnodes.Var.new_obs(x, name="x")
-        bvar = lnodes.Var.new_param(jnp.array([b]), name="b")
-        loc = lnodes.Var.new_calc(lambda x, b: x * b, x=xvar, b=bvar, name="loc")
-        scale = lnodes.Var.new_param(jnp.array([1.0]), name="scale")
+        xvar = lsl.Var.new_obs(x, name="x")
+        bvar = lsl.Var.new_param(jnp.array([b]), name="b")
+        loc = lsl.Var.new_calc(lambda x, b: x * b, x=xvar, b=bvar, name="loc")
+        scale = lsl.Var.new_param(jnp.array([1.0]), name="scale")
         scale.transform(tfp.bijectors.Exp())
-        yvar = lnodes.Var.new_obs(
-            y, lnodes.Dist(tfp.distributions.Normal, loc=loc, scale=scale), name="y"
+        yvar = lsl.Var.new_obs(
+            y, lsl.Dist(tfp.distributions.Normal, loc=loc, scale=scale), name="y"
         )
 
-        _ = lmodel.Model([yvar])
+        _ = lsl.Model([yvar])
 
         samples = {"b": jax.random.uniform(jax.random.PRNGKey(3), (4, 7))}
 
@@ -845,4 +844,3 @@ class TestVarPredictions:
         assert jnp.allclose(pred, xnew * jnp.expand_dims(samples["b"], -1))
         assert pred.shape[-1] != x.shape[-1]
         assert pred.shape[-1] == xnew.shape[-1]
-


### PR DESCRIPTION
This PR adds predictions to Liesel. The predictions are based on updating the model graph with new values repeatedly based on a dictionary of samples. For this, I use `jax.vmap`.

In the process, I added the methods `Model.extract_position()` and `Model.update_state()`, which basically mirror the corresponding methods in the `gs.LieselInterface`.

### Some features:

- Users can supply a dictionary of `newdata` at which to evaluate predictions. If they don't, `predict` uses the current values.
- Users can choose to evaluate predictions only for a subset of variables, indicated by a list of variable names. In this case, a `Model.parental_submodel()` for the selected variables is created. This avoids unnecessary computations and makes it possible to, for example in a regression setting, evaluate predictions on grids for covariates without having to supply response values of fitting shape.
- `Model.predict()` returns a dictionary of predictions for a) all variables in the model (if none are selected specifically), or b) the selected variables and/or nodes.
- `Var.predict()` returns a single array of predictions for this specific variable.


### Demo Notebook:

[test_predictions.ipynb.zip](https://github.com/user-attachments/files/19522955/test_predictions.ipynb.zip)



- Closes #54 