### PR TITLE
Add SamplesSummary

### DIFF
--- a/liesel/goose/__init__.py
+++ b/liesel/goose/__init__.py
@@ -20,7 +20,7 @@ from .models import DataClassModel, DictModel
 from .nuts import NUTSKernel
 from .optim import OptimResult, Stopper, history_to_df, optim_flat
 from .rw import RWKernel
-from .summary_m import Summary
+from .summary_m import SamplesSummary, Summary
 from .summary_viz import (
     plot_cor,
     plot_density,
@@ -55,6 +55,7 @@ __all__ = [
     "Stopper",
     "RWKernel",
     "Summary",
+    "SamplesSummary",
     "SamplingResults",
     "plot_cor",
     "plot_density",

--- a/liesel/goose/summary_m.py
+++ b/liesel/goose/summary_m.py
@@ -690,6 +690,23 @@ class SamplesSummary:
         per_chain: bool = False,
         name: str = "v",
     ) -> SamplesSummary:
+        """
+        Initializes the summary from an array of samples.
+
+        Parameters
+        ----------
+        a
+            The array of samples to summarize.
+        hdi_prob
+            Level on which to return posterior highest density intervals.
+        selected, deselected
+            Allow to get a summary only for a subset of the position keys.
+        per_chain
+            If *True*, the summary is calculated on a per-chain basis. Certain \
+            measures like ``rhat`` are not available if ``per_chain`` is *True*.
+        name
+            Variable name to use for labelling in :meth:`.to_dataframe`.
+        """
         samples = {name: a}
         return cls(samples, quantiles, hdi_prob, selected, deselected, per_chain)
 

--- a/tests/goose/test_summary_m.py
+++ b/tests/goose/test_summary_m.py
@@ -223,11 +223,12 @@ def test_quantity_shape(result_for_quants: SamplingResults):
     assert summary.quantities["hdi"]["bar"].shape == (4, 2, 3, 5, 7)
     assert summary.quantities["hdi"]["baz"].shape == (4, 2)
 
-    
+
 def test_liesel_version(result: SamplingResults):
     summary = Summary(result, per_chain=True)
 
     assert summary.liesel_version == __version__
+
 
 class TestSamplesSummary:
     def test_shapes(self, result: SamplingResults):


### PR DESCRIPTION
This is a convenience summary class that takes a dictionary of samples/predictions as input. It plays very nicely with predictions as proposed in #246 and could also be used to create more targeted summaries for individual parameters.

Pseudocode illustration:

```python
samples = results.get_posterior_samples()
predictions = model.predict(samples)

summary_predictions = SamplesSummary(predictions)
summary_loc = SamplesSummary.from_array(predictions["loc"])
```

The `SamplesSummary` class basically replicates the `Summary.to_dataframe()` method. The way it is implemented in this PR is more of a quick implementation, and it contains large parts of copy-pasted code that was only slightly adapted. It is not very clean. But the whole `Summary` class code is not very clean and could really benefit from a refactoring. However, I did not want to invest the time for a full refactoring in this PR: I want a working implementation of summary functionality based on a dictionary or an array of samples. This class gets the job done. I propose that the code duplication and the general messiness of the code should be tackled in a later refactoring.