### PR TITLE
Add Model.mcmc_engine() method

### DIFF
--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -11,7 +11,7 @@ from collections import Counter
 from collections.abc import Iterable
 from copy import deepcopy
 from types import MappingProxyType
-from typing import IO, Any, Literal, TypeVar
+from typing import IO, TYPE_CHECKING, Any, Literal, TypeVar
 
 import dill
 import jax
@@ -39,6 +39,9 @@ from .nodes import (
     is_bijector_class,
 )
 from .viz import plot_nodes, plot_vars
+
+if TYPE_CHECKING:
+    from ..goose.kernel import Kernel
 
 __all__ = ["GraphBuilder", "Model", "load_model", "save_model"]
 
@@ -1532,6 +1535,12 @@ class Model:
             height=height,
             prog=prog,
         )
+
+    def mcmc_kernels(self) -> dict[str, Kernel]:
+        """Returns dictionary of variable names and corresponding MCMC kernels."""
+        return {
+            k: v.mcmc_kernel for k, v in self.vars.items() if v.mcmc_kernel is not None
+        }
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -1605,6 +1605,11 @@ class Model:
             :class:`.goose.Engine`. Otherwise, it returns a pre-filled \
             :class:`.goose.EngineBuilder`. The latter may be useful for custom changes \
             to the MCMC engine after an initial setup.
+
+        See Also
+        --------
+        .goose.EngineBuilder : The engine builder class.
+        .goose.Engine : The engine class.
         """
 
         eb = EngineBuilder(seed=seed, num_chains=num_chains)

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -1594,7 +1594,7 @@ class Model:
             See :class:`.goose.EngineBuilder`.
         warmup_duration, posterior_duration, term_duration
             See :meth:`.goose.EngineBuilder.set_duration`.
-        thinning_posterior, thinning_war
+        thinning_posterior, thinning_warmup
             See :meth:`.goose.EngineBuilder.set_duration`.
         apply_jitter
             If ``True`` (default), jitter functions will be automatically set with the \

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1722,6 +1722,10 @@ class Var:
         self.parameter = False
         self.dist_node = None
 
+        if self._mcmc_kernel is not None:
+            logger.warning(f"Removing MCMC kernel {self._mcmc_kernel} from {self}.")
+            self._mcmc_kernel = None
+
         return tvar
 
     @in_model_method

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1502,7 +1502,7 @@ class Var:
     def mcmc_kernel(self) -> Kernel | None:
         """MCMC kernel for this variable."""
         if isinstance(self._mcmc_kernel, type):
-            return self._mcmc_kernel([self.name])  # type: ignore
+            self._mcmc_kernel = self._mcmc_kernel([self.name])  # type: ignore
 
         return self._mcmc_kernel
 

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1502,7 +1502,16 @@ class Var:
         return self._mcmc_kernel
 
     @mcmc_kernel.setter
-    def mcmc_kernel(self, value: Kernel):
+    def mcmc_kernel(self, value: type[Kernel] | Kernel | None):
+        if value is None:
+            self._mcmc_kernel = value
+            return
+
+        if self.weak:
+            raise ValueError(f"{self} is weak, cannot set MCMC kernel.")
+        if self.observed:
+            raise ValueError(f"{self} is observed, cannot set MCMC kernel.")
+
         self._mcmc_kernel = value
 
     def all_input_nodes(self) -> tuple[Node, ...]:

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1688,54 +1688,50 @@ class Var:
             )
             tvar.parameter = self.parameter  # type: ignore
             self.parameter = False
-            return tvar
 
         elif self.dist_node is None:
             tvar = _transform_var_without_dist_with_bijector_instance(self, bijector)
             tvar.parameter = self.parameter  # type: ignore
             self.parameter = False
-            return tvar
 
-        if self.dist_node is None:  # type: ignore
-            raise RuntimeError(f"{repr(self)} has no distribution")
-
-        # avoid infinite recursion
-        self.auto_transform = False
-
-        # use default event space bijector if bijector is None
-        use_default_bijector = bijector is None
-        if use_default_bijector:
-            dist_inst = self.dist_node.init_dist()
-            default_bijector = dist_inst.experimental_default_event_space_bijector
-
-        if use_default_bijector and default_bijector is None:
-            raise RuntimeError(
-                f"{self} has distribution without default event space bijector "
-                "and no bijector was given"
-            )
-
-        if is_bijector_class(bijector) or use_default_bijector:
-            tvar = _transform_var_with_bijector_class(
-                self, bijector, *bijector_args, **bijector_kwargs
-            )
-        elif isinstance(bijector, jb.Bijector):
-            if bijector_args or bijector_kwargs:
-                raise RuntimeError(
-                    "You passed a bijector instance and "
-                    "nonempty bijector arguments. You should either initialise your "
-                    "bijector directly with the arguments, or pass a bijector class "
-                    "instead. The first option is preferred, if the bijector arguments"
-                    "are constant."
-                )
-            tvar = _transform_var_with_bijector_instance(self, bijector)
         else:
-            raise TypeError(
-                f"Argument {bijector=} is of invalid type {type(bijector)}."
-            )
+            # avoid infinite recursion
+            self.auto_transform = False
 
-        tvar.parameter = self.parameter  # type: ignore
-        self.parameter = False
-        self.dist_node = None
+            # use default event space bijector if bijector is None
+            use_default_bijector = bijector is None
+            if use_default_bijector:
+                dist_inst = self.dist_node.init_dist()
+                default_bijector = dist_inst.experimental_default_event_space_bijector
+
+            if use_default_bijector and default_bijector is None:
+                raise RuntimeError(
+                    f"{self} has distribution without default event space bijector "
+                    "and no bijector was given"
+                )
+
+            if is_bijector_class(bijector) or use_default_bijector:
+                tvar = _transform_var_with_bijector_class(
+                    self, bijector, *bijector_args, **bijector_kwargs
+                )
+            elif isinstance(bijector, jb.Bijector):
+                if bijector_args or bijector_kwargs:
+                    raise RuntimeError(
+                        "You passed a bijector instance and nonempty bijector"
+                        " arguments. You should either initialise your bijector"
+                        " directly with the arguments, or pass a bijector class"
+                        " instead. The first option is preferred, if the bijector"
+                        " argumentsare constant."
+                    )
+                tvar = _transform_var_with_bijector_instance(self, bijector)
+            else:
+                raise TypeError(
+                    f"Argument {bijector=} is of invalid type {type(bijector)}."
+                )
+
+            tvar.parameter = self.parameter  # type: ignore
+            self.parameter = False
+            self.dist_node = None
 
         if self._mcmc_kernel is not None:
             logger.warning(f"Removing MCMC kernel {self._mcmc_kernel} from {self}.")

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -1302,7 +1302,6 @@ class Var:
         value: Any,
         distribution: Dist | None = None,
         name: str = "",
-        mcmc_kernel: type[Kernel] | Kernel | None = None,
     ) -> Var:
         """
         Initializes a strong variable that holds observed data.
@@ -1320,10 +1319,6 @@ class Var:
         name
             The name of the variable. If you do not specify a name, a unique name will \
             be automatically generated upon initialization of a :class:`.Model`.
-        mcmc_kernel
-            A :class:`.goose.Kernel` instance or class for easy access via the \
-            :attr:`.mcmc_kernel` attribute and collection in the \
-            :meth:`~liesel.model.Model.mcmc_kernels` method.
 
         See Also
         --------
@@ -1349,7 +1344,7 @@ class Var:
         Var(name="")
 
         """
-        var = cls(value, distribution, name, mcmc_kernel=mcmc_kernel)
+        var = cls(value, distribution, name)
         var.observed = True
         return var
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -381,6 +381,27 @@ class TestModel:
         assert len(kernels) == 1
         assert isinstance(kernels["mu"], gs.NUTSKernel)
 
+    @pytest.mark.mcmc
+    def test_mcmc_engine(self):
+        mu = Var(
+            value=0.0,
+            distribution=Dist(tfd.Normal, loc=0.0, scale=1.0),
+            name="mu",
+            mcmc_kernel=gs.NUTSKernel,
+        )
+
+        y = Var(
+            jnp.linspace(-3, 3, 50),
+            distribution=Dist(tfd.Normal, loc=mu, scale=1.0),
+            name="y",
+        )
+
+        model = Model([y])
+        engine = model.mcmc_engine(
+            seed=1, num_chains=4, warmup_duration=200, posterior_duration=20
+        )
+        engine.sample_all_epochs()
+
 
 @pytest.mark.xfail
 class TestUserDefinedModelNodes:

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -10,6 +10,7 @@ import jax.random as rnd
 import pytest
 import tensorflow_probability.substrates.jax.distributions as tfd
 
+import liesel.goose as gs
 from liesel.model.model import GraphBuilder, Model, save_model
 from liesel.model.nodes import Calc, Dist, Group, TransientNode, Value, Var
 
@@ -350,6 +351,35 @@ class TestModel:
 
         assert "x_transformed" in new_model.vars
         assert new_model.vars["x_transformed"].value == pytest.approx(0.54132485)
+
+    def test_mcmc_kernels(self):
+        mu = Var(
+            value=0.0,
+            distribution=Dist(tfd.Normal, loc=0.0, scale=1.0),
+            name="mu",
+            mcmc_kernel=gs.NUTSKernel,
+        )
+
+        model = Model([mu])
+
+        kernels = model.mcmc_kernels()
+
+        assert len(kernels) == 1
+        assert isinstance(kernels["mu"], gs.NUTSKernel)
+
+        mu = Var(
+            value=0.0,
+            distribution=Dist(tfd.Normal, loc=0.0, scale=1.0),
+            name="mu",
+            mcmc_kernel=gs.NUTSKernel(["mu"]),
+        )
+
+        model = Model([mu])
+
+        kernels = model.mcmc_kernels()
+
+        assert len(kernels) == 1
+        assert isinstance(kernels["mu"], gs.NUTSKernel)
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
This PR depends on the two following PRs:

- #244 
- #249 

It introduces a convenience method `Model.mcmc_engine` for quick setup of a goose `Engine` based on the current model.