### PR TITLE
Allow samples dictionary in plotting functions

### DIFF
--- a/liesel/goose/summary_viz.py
+++ b/liesel/goose/summary_viz.py
@@ -14,6 +14,8 @@ import seaborn as sns
 
 from liesel.goose.engine import SamplingResults
 
+from .types import Array
+
 
 def _raise_chain_indices_error(
     chain_indices: Sequence[int], num_original_chains: int
@@ -254,7 +256,7 @@ def _collect_subparam_dfs(
 
 
 def _collect_param_dfs(
-    results: SamplingResults,
+    results: SamplingResults | dict[str, Array],
     params: str | list[str] | None = None,
     param_indices: int | Sequence[int] | None = None,
     chain_indices: int | Sequence[int] | None = None,
@@ -263,10 +265,13 @@ def _collect_param_dfs(
 ) -> pd.DataFrame:
     """Combines individual data frames for each parameter into a single data frame."""
 
-    if include_warmup:
+    if isinstance(results, dict):
+        samples = results
+    elif include_warmup:
         samples = results.get_samples()
     else:
         samples = results.get_posterior_samples()
+
     params = _validate_params(samples, params)
 
     return pd.concat(
@@ -280,7 +285,7 @@ def _collect_param_dfs(
 
 
 def _setup_plot_df(
-    results: SamplingResults,
+    results: SamplingResults | dict[str, Array],
     params: str | list[str] | None,
     param_indices: int | Sequence[int] | None,
     chain_indices: int | Sequence[int] | None,
@@ -300,7 +305,7 @@ def _setup_plot_df(
 
 
 def _setup_scatterplot_df(
-    results: SamplingResults,
+    results: SamplingResults | dict[str, Array],
     params: str | list[str] | None,
     param_indices: int | Sequence[int] | None,
     chain_indices: int | Sequence[int] | None,
@@ -384,7 +389,7 @@ def save_figure(g: sns.FacetGrid | None = None, save_path: str | None = None) ->
 
 
 def plot_trace(
-    results: SamplingResults,
+    results: SamplingResults | dict[str, Array],
     params: str | list[str] | None = None,
     param_indices: int | Sequence[int] | None = None,
     chain_indices: int | Sequence[int] | None = None,
@@ -409,7 +414,8 @@ def plot_trace(
     results
         Result object of the sampling process. Must have a method
         ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution.
+        distribution. Alternatively, you can directly supply a dictionary of samples,
+        for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
         Names of the model parameters that are contained in the plot. Must coincide
         with the dictionary keys of the `Position` with the posterior samples. If
@@ -499,7 +505,7 @@ def plot_trace(
 
 
 def plot_density(
-    results: SamplingResults,
+    results: SamplingResults | dict[str, Array],
     params: str | list[str] | None = None,
     param_indices: int | Sequence[int] | None = None,
     chain_indices: int | Sequence[int] | None = None,
@@ -523,7 +529,8 @@ def plot_density(
     results
         Result object of the sampling process. Must have a method
         ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution.
+        distribution. Alternatively, you can directly supply a dictionary of samples,
+        for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
         Names of the model parameters that are contained in the plot. Must coincide
         with the dictionary keys of the ``Position`` with the posterior samples. If
@@ -623,7 +630,7 @@ def _compute_max_lags(
 
 
 def plot_cor(
-    results: SamplingResults,
+    results: SamplingResults | dict[str, Array],
     params: str | list[str] | None = None,
     param_indices: int | Sequence[int] | None = None,
     chain_indices: int | Sequence[int] | None = None,
@@ -648,7 +655,8 @@ def plot_cor(
     results
         Result object of the sampling process. Must have a method
         ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution.
+        distribution. Alternatively, you can directly supply a dictionary of samples,
+        for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
         Names of the model parameters that are contained in the plot. Must coincide
         with the dictionary keys of the ``Position`` with the posterior samples. If
@@ -856,7 +864,7 @@ def _get_title(plot_df: pd.DataFrame, title: str | None) -> str:
 
 
 def plot_param(
-    results: SamplingResults,
+    results: SamplingResults | dict[str, Array],
     param: str,
     param_index: int | None = None,
     chain_indices: int | Sequence[int] | None = None,
@@ -880,7 +888,8 @@ def plot_param(
     results
         Result object of the sampling process. Must have a method
         ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution.
+        distribution. Alternatively, you can directly supply a dictionary of samples,
+        for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     param
         Name of a single model parameter that is contained in the plot. Must coincide
         with one dictionary key of the ``Position`` with the posterior samples.
@@ -954,7 +963,7 @@ def plot_param(
 
 
 def plot_scatter(
-    results: SamplingResults,
+    results: SamplingResults | dict[str, Array],
     params: list[str],
     param_indices: tuple[int, int],
     chain_indices: int | Sequence[int] | None = None,
@@ -977,7 +986,8 @@ def plot_scatter(
     results
         Result object of the sampling process. Must have a method
         ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution.
+        distribution. Alternatively, you can directly supply a dictionary of samples,
+        for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
         Names of the model parameters that are contained in the plot. Must coincide with
         the dictionary keys of the ``Position`` with the posterior samples.
@@ -1072,7 +1082,7 @@ def plot_scatter(
 
 
 def plot_pairs(
-    results: SamplingResults,
+    results: SamplingResults | dict[str, Array],
     params: str | list[str] | None = None,
     param_indices: int | Sequence[int] | None = None,
     chain_indices: int | Sequence[int] | None = None,
@@ -1096,7 +1106,8 @@ def plot_pairs(
     results
         Result object of the sampling process. Must have a method
         ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution.
+        distribution. Alternatively, you can directly supply a dictionary of samples,
+        for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
         Names of the model parameters that are contained in the plot. Must coincide with
         the dictionary keys of the ``Position`` with the posterior samples. If ``None``,

--- a/liesel/goose/summary_viz.py
+++ b/liesel/goose/summary_viz.py
@@ -412,54 +412,54 @@ def plot_trace(
     Parameters
     ----------
     results
-        Result object of the sampling process. Must have a method
-        ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution. Alternatively, you can directly supply a dictionary of samples,
+        Result object of the sampling process. Must have a method \
+        ``get_posterior_samples()`` which extracts all samples from the posterior \
+        distribution. Alternatively, you can directly supply a dictionary of samples, \
         for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
-        Names of the model parameters that are contained in the plot. Must coincide
-        with the dictionary keys of the `Position` with the posterior samples. If
+        Names of the model parameters that are contained in the plot. Must coincide \
+        with the dictionary keys of the `Position` with the posterior samples. If \
         `None`, all parameters are included.
     param_indices
-        Indices of each model parameter that are contained in the plot. Selects e.g.
-        ``beta[0]`` out of a ``beta`` parameter vector. A single index can be specified
-        as an integer or a sequence containing one integer. If ``None``, all
-        subparameters are included.
+        Indices of each model parameter that are contained in the plot. Selects e.g. \
+        ``beta[0]`` out of a ``beta`` parameter vector. A single index can be \
+        specified as an integer or a sequence containing one integer. If ``None``, \
+        all subparameters are included.
     chain_indices
-        Indices of chains for each model subparameter that are contained in the plot.
-        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be
-        specified as an integer or a sequence containing one integer. If ``None``, all
+        Indices of chains for each model subparameter that are contained in the plot. \
+        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be \
+        specified as an integer or a sequence containing one integer. If ``None``, all \
         chains are included.
     max_chains
-        Upper bound how many chains are included within each subplot/facet. Avoids
-        overplotting. If ``None``, all chains contained in the ``results`` input are
-        plotted. Always starts chain selection from the lowest chain index upwards. For
-        selecting specific chains use the argument ``chain_indices``.
+        Upper bound how many chains are included within each subplot/facet. Avoids \
+        overplotting. If ``None``, all chains contained in the ``results`` input are \
+        plotted. Always starts chain selection from the lowest chain index upwards. \
+        For selecting specific chains use the argument ``chain_indices``.
     title
         Plot title.
     title_spacing
-        Determines the margin/whitespace between the plot title (set with
-        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the ``top``
-        argument of ``fig.subplots_adjust()``.
+        Determines the margin/whitespace between the plot title (set with \
+        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the \
+        ``top`` argument of ``fig.subplots_adjust()``.
     xlabel
         Label of the x-axis.
     style
-        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are
+        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are \
         ``"darkgrid"``, ``"whitegrid"``, ``"dark"``, ``"white"``, and ``"ticks"``.
     color_palette
-        Passed to the palette argument of ``sns.relplot()``. String values must be
-        valid inputs of ``sns.color_palette()`` such as a seaborn color palette or a
-        matplotlib colormap. Custom colors can be set with a list of color strings or a
-        dictionary with the chain indices as keys and color strings as values. The
-        number of color strings must coincide with the number of plotted chains. If
-        ``None``, the default ``tab10`` matplotlib colormap is chosen.
+        Passed to the palette argument of ``sns.relplot()``. String values must be \
+        valid inputs of ``sns.color_palette()`` such as a seaborn color palette or a \
+        matplotlib colormap. Custom colors can be set with a list of color strings \
+        or a dictionary with the chain indices as keys and color strings as values. \
+        The number of color strings must coincide with the number of plotted chains. \
+        If ``None``, the default ``tab10`` matplotlib colormap is chosen.
     ncol
         Number of subplots/facets within each row of the grid.
     height
         Height in inches of each subplot/facet within the grid.
     aspect_ratio
-        Ratio of width / height of each subplot/facet within the grid, i.e. ``width =
-        aspect_ratio * height``.
+        Ratio of width / height of each subplot/facet within the grid, i.e. \
+        ``width = aspect_ratio * height``.
     save_path
         File path where the plot is saved.
     include_warmup
@@ -527,54 +527,54 @@ def plot_density(
     Parameters
     ----------
     results
-        Result object of the sampling process. Must have a method
-        ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution. Alternatively, you can directly supply a dictionary of samples,
+        Result object of the sampling process. Must have a method \
+        ``get_posterior_samples()`` which extracts all samples from the posterior \
+        distribution. Alternatively, you can directly supply a dictionary of samples, \
         for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
-        Names of the model parameters that are contained in the plot. Must coincide
-        with the dictionary keys of the ``Position`` with the posterior samples. If
+        Names of the model parameters that are contained in the plot. Must coincide \
+        with the dictionary keys of the ``Position`` with the posterior samples. If \
         ``None``, all parameters are included.
     param_indices
-        Indices of each model parameter that are contained in the plot. Selects e.g.
-        ``beta[0]`` out of a ``beta`` parameter vector. A single index can be specified
-        as an integer or a sequence containing one integer. If ``None``, all
-        subparameters are included.
+        Indices of each model parameter that are contained in the plot. Selects e.g. \
+        ``beta[0]`` out of a ``beta`` parameter vector. A single index can be  \
+        specified as an integer or a sequence containing one integer. If ``None``,  \
+        all subparameters are included.
     chain_indices
-        Indices of chains for each model subparameter that are contained in the plot.
-        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be
-        specified as an integer or a sequence containing one integer. If ``None``, all
-        chains are included.
+        Indices of chains for each model subparameter that are contained in the plot. \
+        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can  \
+        be specified as an integer or a sequence containing one integer. If ``None``, \
+        all chains are included.
     max_chains
-        Upper bound how many chains are included within each subplot/facet. Avoids
-        overplotting. If ``None``, all chains contained in the ``results`` input are
-        plotted. Always starts chain selection from the lowest chain index upwards. For
-        selecting specific chains use the argument ``chain_indices``.
+        Upper bound how many chains are included within each subplot/facet. Avoids \
+        overplotting. If ``None``, all chains contained in the ``results`` input are \
+        plotted. Always starts chain selection from the lowest chain index upwards.  \
+        For selecting specific chains use the argument ``chain_indices``.
     title
         Plot title.
     title_spacing
-        Determines the margin/whitespace between the plot title (set with
-        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the ``top``
-        argument of ``fig.subplots_adjust()``.
+        Determines the margin/whitespace between the plot title (set with \
+        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the  \
+        ``top`` argument of ``fig.subplots_adjust()``.
     xlabel
         Label of the x-axis.
     style
-        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are
+        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are \
         ``darkgrid``, ``whitegrid``, ``dark``, ``white``, and ``ticks``.
     color_palette
-        Passed to the palette argument of ``sns.displot()``. String values must be
-        valid inputs of ``sns.color_palette()`` such as a seaborn color palette or a
-        matplotlib colormap. Custom colors can be set with a list of color strings or a
-        dictionary with the chain indices as keys and color strings as values. The
-        number of color strings must coincide with the number of plotted chains. If
+        Passed to the palette argument of ``sns.displot()``. String values must be  \
+        valid inputs of ``sns.color_palette()`` such as a seaborn color palette or a \
+        matplotlib colormap. Custom colors can be set with a list of color strings or  \
+        a dictionary with the chain indices as keys and color strings as values. The \
+        number of color strings must coincide with the number of plotted chains. If \
         ``None``, the default ``tab10`` matplotlib colormap is chosen.
     ncol
         Number of subplots/facets within each row of the grid.
     height
         Height in inches of each subplot/facet within the grid.
     aspect_ratio
-        Ratio of width / height of each subplot/facet within the grid, i.e. ``width =
-        aspect_ratio * height``.
+        Ratio of width / height of each subplot/facet within the grid, i.e.  \
+        ``width = aspect_ratio * height``.
     save_path
         File path where the plot is saved.
     **kwargs
@@ -653,57 +653,57 @@ def plot_cor(
     Parameters
     ----------
     results
-        Result object of the sampling process. Must have a method
-        ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution. Alternatively, you can directly supply a dictionary of samples,
+        Result object of the sampling process. Must have a method \
+        ``get_posterior_samples()`` which extracts all samples from the posterior \
+        distribution. Alternatively, you can directly supply a dictionary of samples, \
         for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
-        Names of the model parameters that are contained in the plot. Must coincide
-        with the dictionary keys of the ``Position`` with the posterior samples. If
+        Names of the model parameters that are contained in the plot. Must coincide \
+        with the dictionary keys of the ``Position`` with the posterior samples. If \
         ``None``, all parameters are included.
     param_indices
-        Indices of each model parameter that are contained in the plot. Selects e.g.
-        ``beta[0]`` out of a ``beta`` parameter vector. A single index can be specified
-        as an integer or a sequence containing one integer. If ``None``, all
+        Indices of each model parameter that are contained in the plot. Selects e.g. \
+        ``beta[0]`` out of a ``beta`` parameter vector. A single index can be  \
+        specified as an integer or a sequence containing one integer. If ``None``, all \
         subparameters are included.
     chain_indices
-        Indices of chains for each model subparameter that are contained in the plot.
-        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be
-        specified as an integer or a sequence containing one integer. If ``None``, all
+        Indices of chains for each model subparameter that are contained in the plot. \
+        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be \
+        specified as an integer or a sequence containing one integer. If ``None``, all \
         chains are included.
     max_chains
-        Upper bound how many chains are included within each subplot/facet. Avoids
-        overplotting. If ``None``, all chains contained in the ``results`` input are
-        plotted. Always starts chain selection from the lowest chain index upwards. For
-        selecting specific chains use the argument ``chain_indices``.
+        Upper bound how many chains are included within each subplot/facet. Avoids \
+        overplotting. If ``None``, all chains contained in the ``results`` input are \
+        plotted. Always starts chain selection from the lowest chain index upwards.  \
+        For selecting specific chains use the argument ``chain_indices``.
     max_lags
-        Maximum number of time lags shown on the x-axis of the autocorrelation plot. If
-        ``None``, the minimum of the chain lengths and 30 is chosen.
+        Maximum number of time lags shown on the x-axis of the autocorrelation plot.  \
+        If ``None``, the minimum of the chain lengths and 30 is chosen.
     title
         Plot title.
     title_spacing
-        Determines the margin/whitespace between the plot title (set with
-        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the ``top``
-        argument of ``fig.subplots_adjust()``.
+        Determines the margin/whitespace between the plot title (set with \
+        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the  \
+        ``top`` argument of ``fig.subplots_adjust()``.
     xlabel
         Label of the x-axis.
     style
-        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are
+        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are \
         ``darkgrid``, ``whitegrid``, ``dark``, ``white``, and ``ticks``.
     color_palette
-        Passed to the palette argument of ``sns.FacetGrid()``. String values must be
-        valid inputs of ``sns.color_palette()`` such as a seaborn color palette or a
-        matplotlib colormap. Custom colors can be set with a list of color strings or a
-        dictionary with the chain indices as keys and color strings as values. The
-        number of color strings must coincide with the number of plotted chains. If
+        Passed to the palette argument of ``sns.FacetGrid()``. String values must be \
+        valid inputs of ``sns.color_palette()`` such as a seaborn color palette or a \
+        matplotlib colormap. Custom colors can be set with a list of color strings or  \
+        a dictionary with the chain indices as keys and color strings as values. The \
+        number of color strings must coincide with the number of plotted chains. If \
         ``None``, the default ``tab10`` matplotlib colormap is chosen.
     ncol
         Number of subplots/facets within each row of the grid.
     height
         Height in inches of each subplot/facet within the grid.
     aspect_ratio
-        Ratio of width / height of each subplot/facet within the grid, i.e. ``width =
-        aspect_ratio * height``.
+        Ratio of width / height of each subplot/facet within the grid, i.e.  \
+        ``width = aspect_ratio * height``.
     save_path
         File path where the plot is saved.
     **kwargs
@@ -886,52 +886,53 @@ def plot_param(
     Parameters
     ----------
     results
-        Result object of the sampling process. Must have a method
-        ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution. Alternatively, you can directly supply a dictionary of samples,
+        Result object of the sampling process. Must have a method \
+        ``get_posterior_samples()`` which extracts all samples from the posterior \
+        distribution. Alternatively, you can directly supply a dictionary of samples, \
         for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     param
-        Name of a single model parameter that is contained in the plot. Must coincide
+        Name of a single model parameter that is contained in the plot. Must coincide \
         with one dictionary key of the ``Position`` with the posterior samples.
     param_index
-        A single index of the selected model parameter that is contained in the plot.
-        Selects e.g. ``beta[0]`` out of a ``beta`` parameter vector. Can be specified
-        as an integer or as a sequence containing one integer. If ``None``, the
+        A single index of the selected model parameter that is contained in the plot. \
+        Selects e.g. ``beta[0]`` out of a ``beta`` parameter vector. Can be specified \
+        as an integer or as a sequence containing one integer. If ``None``, the \
         parameter is assumed to have only a single index.
     chain_indices
-        Indices of chains for each model subparameter that are contained in the plot.
-        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be
-        specified as an integer or a sequence containing one integer. If ``None``, all
+        Indices of chains for each model subparameter that are contained in the plot. \
+        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be \
+        specified as an integer or a sequence containing one integer. If ``None``, all \
         chains are included.
     max_chains
-        Upper bound how many chains are included within each subplot/facet. Avoids
-        overplotting. If ``None``, all chains contained in the ``results`` input are
-        plotted. Always starts chain selection from the lowest chain index upwards. For
-        selecting specific chains use the argument ``chain_indices``.
+        Upper bound how many chains are included within each subplot/facet. Avoids \
+        overplotting. If ``None``, all chains contained in the ``results`` input are \
+        plotted. Always starts chain selection from the lowest chain index upwards.  \
+        For selecting specific chains use the argument ``chain_indices``.
     max_lags
-        Maximum number of time lags shown on the x-axis of the autocorrelation plot. If
-        ``None``, the minimum of the chain lengths and 30 is chosen.
+        Maximum number of time lags shown on the x-axis of the autocorrelation plot.  \
+        If ``None``, the minimum of the chain lengths and 30 is chosen.
     title
         Plot title.
     title_spacing
-        Determines the margin/whitespace between the plot title (set with
-        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the ``top``
-        argument of ``fig.subplots_adjust()``.
+        Determines the margin/whitespace between the plot title (set with \
+        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the  \
+        ``top`` argument of ``fig.subplots_adjust()``.
     style
-        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are
+        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are \
         ``darkgrid``, ``whitegrid``, ``dark``, ``white``, and ``ticks``.
     color_list
-        Determines the chain colors for all three subplots. Custom colors can be passed
-        with a list of color strings. The length of the list must match the number of
-        chains. If ``None``, the default ``tab10`` matplotlib colormap is chosen.
+        Determines the chain colors for all three subplots. Custom colors can be  \
+        passed with a list of color strings. The length of the list must match the \
+        number of chains. If ``None``, the default ``tab10`` matplotlib colormap is \
+        chosen.
     figure_size
-        Size of the entire plot grid. Passed to the ``figsize`` argument of
-        ``plt.figure()``. When changing the figure size consider changing the
+        Size of the entire plot grid. Passed to the ``figsize`` argument of \
+        ``plt.figure()``. When changing the figure size consider changing the \
         ``legend_position`` as well. Generally, a ratio of 3
     legend_position
-        Determines the color legend position. Coordinates are relative to the upper
-        panel within the plot grid. The first coordinate specifies the horizontal, the
-        second coordinate the vertical position. Might require an adjustment when
+        Determines the color legend position. Coordinates are relative to the upper \
+        panel within the plot grid. The first coordinate specifies the horizontal,  \
+        the second coordinate the vertical position. Might require an adjustment when \
         changing the ``figure_size`` values or the number of chains.
     save_path
         File path where the plot is saved.
@@ -984,55 +985,56 @@ def plot_scatter(
     Parameters
     ----------
     results
-        Result object of the sampling process. Must have a method
-        ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution. Alternatively, you can directly supply a dictionary of samples,
+        Result object of the sampling process. Must have a method \
+        ``get_posterior_samples()`` which extracts all samples from the posterior \
+        distribution. Alternatively, you can directly supply a dictionary of samples, \
         for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
-        Names of the model parameters that are contained in the plot. Must coincide with
-        the dictionary keys of the ``Position`` with the posterior samples.
+        Names of the model parameters that are contained in the plot. Must coincide  \
+        with the dictionary keys of the ``Position`` with the posterior samples.
     param_indices
-        Indices of each model parameter that are contained in the plot. Selects e.g.
-        ``beta[0]`` out of a ``beta`` parameter vector. If only one string is supplied
-        as the value of ``params``, ``param_indices`` must contain two indices. If a
-        sequence of two strings is supplied to ``params``, you can supply either a
-        single integer or a tuple of two integers. A single integer will be used as the
-        index for *both* parameters. If you use a tuple of two integers, the first
-        element will be used as the index for the first parameter, and the second
+        Indices of each model parameter that are contained in the plot. Selects e.g. \
+        ``beta[0]`` out of a ``beta`` parameter vector. If only one string is supplied \
+        as the value of ``params``, ``param_indices`` must contain two indices. If a \
+        sequence of two strings is supplied to ``params``, you can supply either a \
+        single integer or a tuple of two integers. A single integer will be used as  \
+        the index for *both* parameters. If you use a tuple of two integers, the first \
+        element will be used as the index for the first parameter, and the second \
         element will be used as the index for the second parameter.
     chain_indices
-        Indices of chains for each model subparameter that are contained in the plot.
-        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be
-        specified as an integer or a sequence containing one integer. If ``None``, all
+        Indices of chains for each model subparameter that are contained in the plot. \
+        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be \
+        specified as an integer or a sequence containing one integer. If ``None``, all \
         chains are included.
     max_chains
-        Upper bound how many chains are included within each subplot/facet. Avoids
-        overplotting. If ``None``, all chains contained in the ``results`` input are
-        plotted. Always starts chain selection from the lowest chain index upwards. For
-        selecting specific chains use the argument ``chain_indices``.
+        Upper bound how many chains are included within each subplot/facet. Avoids \
+        overplotting. If ``None``, all chains contained in the ``results`` input are \
+        plotted. Always starts chain selection from the lowest chain index upwards.  \
+        For selecting specific chains use the argument ``chain_indices``.
     alpha
         Amount of transparency; a float between 0 and 1.
     title
         Plot title.
     title_spacing
-        Determines the margin/whitespace between the plot title (set with
-        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the ``top``
-        argument of ``fig.subplots_adjust()``.
+        Determines the margin/whitespace between the plot title (set with \
+        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the  \
+        ``top`` argument of ``fig.subplots_adjust()``.
     style
-        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are
+        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are \
         ``darkgrid``, ``whitegrid``, ``dark``, ``white``, and ``ticks``.
     color_list
-        Determines the chain colors for all three subplots. Custom colors can be passed
-        with a list of color strings. The length of the list must match the number of
-        chains. If ``None``, the default ``tab10`` matplotlib colormap is chosen.
+        Determines the chain colors for all three subplots. Custom colors can be  \
+        passed with a list of color strings. The length of the list must match the \
+        number of chains. If ``None``, the default ``tab10`` matplotlib colormap is \
+        chosen.
     figure_size
-        Size of the entire plot grid. Passed to the ``figsize`` argument of
-        ``plt.figure()``. When changing the figure size consider changing the
+        Size of the entire plot grid. Passed to the ``figsize`` argument of \
+        ``plt.figure()``. When changing the figure size consider changing the \
         ``legend_position`` as well. Generally, a ratio of 3
     legend_position
-        Determines the color legend position. Coordinates are relative to the upper
-        panel within the plot grid. The first coordinate specifies the horizontal, the
-        second coordinate the vertical position. Might require an adjustment when
+        Determines the color legend position. Coordinates are relative to the upper \
+        panel within the plot grid. The first coordinate specifies the horizontal, the \
+        second coordinate the vertical position. Might require an adjustment when \
         changing the ``figure_size`` values or the number of chains.
     save_path
         File path where the plot is saved.
@@ -1104,59 +1106,59 @@ def plot_pairs(
     Parameters
     ----------
     results
-        Result object of the sampling process. Must have a method
-        ``get_posterior_samples()`` which extracts all samples from the posterior
-        distribution. Alternatively, you can directly supply a dictionary of samples,
+        Result object of the sampling process. Must have a method \
+        ``get_posterior_samples()`` which extracts all samples from the posterior \
+        distribution. Alternatively, you can directly supply a dictionary of samples, \
         for example the output of :meth:`.SamplingResults.get_posterior_samples`.
     params
-        Names of the model parameters that are contained in the plot. Must coincide with
-        the dictionary keys of the ``Position`` with the posterior samples. If ``None``,
-        all parameters are included.
+        Names of the model parameters that are contained in the plot. Must coincide  \
+        with the dictionary keys of the ``Position`` with the posterior samples. If \
+        ``None``, all parameters are included.
     param_indices
-        Indices of each model parameter that are contained in the plot. Selects e.g.
-        ``beta[0]`` out of a ``beta`` parameter vector. A single index can be specified
-        as an integer or a sequence containing one integer. If ``None``, all
+        Indices of each model parameter that are contained in the plot. Selects e.g. \
+        ``beta[0]`` out of a ``beta`` parameter vector. A single index can be  \
+        specified as an integer or a sequence containing one integer. If ``None``, all \
         subparameters are included.
     chain_indices
-        Indices of chains for each model subparameter that are contained in the plot.
-        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can be
-        specified as an integer or a sequence containing one integer. If ``None``, all
-        chains are included.
+        Indices of chains for each model subparameter that are contained in the plot. \
+        Selects e.g. chain 0 and chain 2 out of multiple chains. A single index can  \
+        be specified as an integer or a sequence containing one integer. If ``None``, \
+        all chains are included.
     max_chains
-        Upper bound how many chains are included within each subplot/facet. Avoids
-        overplotting. If ``None``, all chains contained in the ``results`` input are
-        plotted. Always starts chain selection from the lowest chain index upwards. For
-        selecting specific chains use the argument ``chain_indices``.
+        Upper bound how many chains are included within each subplot/facet. Avoids \
+        overplotting. If ``None``, all chains contained in the ``results`` input are \
+        plotted. Always starts chain selection from the lowest chain index upwards.  \
+        For selecting specific chains use the argument ``chain_indices``.
     alpha
         Amount of transparency; a float between 0 and 1.
     title
         Plot title.
     title_spacing
-        Determines the margin/whitespace between the plot title (set with
-        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the ``top``
-        argument of ``fig.subplots_adjust()``.
+        Determines the margin/whitespace between the plot title (set with \
+        ``fig.suptitle()``) and the first row of subplots/facets. Passed to the  \
+        ``top`` argument of ``fig.subplots_adjust()``.
     style
-        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are
+        Passed to the ``style`` argument of ``sns.set_theme()``. Valid options are \
         ``darkgrid``, ``whitegrid``, ``dark``, ``white``, and ``ticks``.
     diag_kind
-        Kind of plot for the diagonal subplots. Can be 'kde' (default) for kernel
+        Kind of plot for the diagonal subplots. Can be 'kde' (default) for kernel \
         density estimates or 'hist' for histograms.
     color_palette
-        Passed to the palette argument of ``sns.pairplot()``. String values must be
-        valid inputs of ``sns.color_palette()`` such as a seaborn color palette or a
-        matplotlib colormap. Custom colors can be set with a list of color strings or a
-        dictionary with the chain indices as keys and color strings as values. The
-        number of color strings must coincide with the number of plotted chains. If
+        Passed to the palette argument of ``sns.pairplot()``. String values must be \
+        valid inputs of ``sns.color_palette()`` such as a seaborn color palette or a \
+        matplotlib colormap. Custom colors can be set with a list of color strings or  \
+        a dictionary with the chain indices as keys and color strings as values. The \
+        number of color strings must coincide with the number of plotted chains. If \
         ``None``, the default ``tab10`` matplotlib colormap is chosen.
     height
         Height in inches of each subplot/facet within the grid.
     aspect_ratio
-        Ratio of width / height of each subplot/facet within the grid, i.e. ``width =
-        aspect_ratio * height``.
+        Ratio of width / height of each subplot/facet within the grid, i.e.  \
+        ``width = aspect_ratio * height``.
     legend_position
-        Determines the color legend position. Coordinates are relative to the upper
-        panel within the plot grid. The first coordinate specifies the horizontal, the
-        second coordinate the vertical position. Might require an adjustment when
+        Determines the color legend position. Coordinates are relative to the upper \
+        panel within the plot grid. The first coordinate specifies the horizontal, the \
+        second coordinate the vertical position. Might require an adjustment when \
         changing the ``figure_size`` values or the number of chains.
     save_path
         File path where the plot is saved.


### PR DESCRIPTION
The PR does what it says. In addition to

```python
results = engine.get_results()
samples = results.get_posterior_samples()

gs.plot_trace(results)
```

it is now possible to do 

```python
gs.plot_trace(samples)
```

for all plotting functions.

This is really useful in combination with predictions (#246), because you can look at diagnostic plots for computed quantities without having to include them in `eb.positions_included` during sampling, i.e. without having to have them baked into the `gs.SamplingResults` object.