### PR TITLE
Implement logprob convenience for Liesel models

### DIFF
--- a/liesel/model/__init__.py
+++ b/liesel/model/__init__.py
@@ -21,6 +21,7 @@ from .legacy import (
     Smooth,
     SmoothingParam,
 )
+from .logprob import FlatLogProb, LogProb
 from .model import GraphBuilder, Model, load_model, save_model
 from .nodes import (  # TODO: Bijector?
     Array,

--- a/liesel/model/logprob.py
+++ b/liesel/model/logprob.py
@@ -1,0 +1,138 @@
+from typing import Literal
+
+import jax
+import jax.flatten_util
+
+from ..goose.types import Array
+from .model import Model
+
+
+class LogProb:
+    """
+    Interface for evaluating the unnormalized log probability of a Liesel model.
+
+    Also provides access to the first and second derivatives.
+
+    Parameters
+    ----------
+    model
+        A Liesel model instance.
+    component
+        Which component of the model's log probability to evaluate.
+    diff_mode
+        Which auto-diff mode to use for the Hessian.
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        component: Literal["log_prob", "log_lik", "log_prior"] = "log_prob",
+        diff_mode: Literal["forward", "reverse"] = "forward",
+    ):
+        self.model = model
+        self._grad_fn = jax.grad(self.log_prob)
+
+        if diff_mode == "forward":
+            self._hessian_fn = jax.jacfwd(self._grad_fn)
+        elif diff_mode == "reverse":
+            self._hessian_fn = jax.jacrev(self._grad_fn)
+        else:
+            raise ValueError(f"Unrecognized argumetn value {diff_mode=}")
+
+        self.component = component
+        self.diff_mode = diff_mode
+
+    def __call__(self, position: dict[str, Array | float]) -> Array:
+        return self.log_prob(position=position)
+
+    def log_prob(self, position: dict[str, Array | float]) -> Array:
+        """
+        Log probability function evaluated at provided ``position``.
+        """
+        updated_state = self.model.update_state(position, self.model.state)
+        return updated_state[f"_model_{self.component}"].value
+
+    def grad(self, position: dict[str, Array | float]) -> dict[str, Array]:
+        """
+        Gradient of the log probability function with respect to the ``position``.
+        """
+        return self._grad_fn(position)
+
+    def hessian(
+        self,
+        position: dict[str, Array | float],
+    ) -> dict[str, Array]:
+        """
+        Hessian of the log probability function with respect to the ``position``.
+        """
+        return self._hessian_fn(position)
+
+
+class FlatLogProb:
+    """
+    Interface for evaluating the unnormalized log probability of a Liesel model.
+
+    Also provides access to the first and second derivatives.
+    The methods :meth:`.FlatLogProb.grad` and :meth:`.FlatLogProb.hessian` are
+    flattened, which means the expect arrays as inputs and return arrays.
+
+    Parameters
+    ----------
+    *names
+        Names of the variables at which to evaluate the log probability. Other \
+        variables will be kept fixed at their current values in the model state.
+    model
+        A Liesel model instance.
+    component
+        Which component of the model's log probability to evaluate.
+    diff_mode
+        Which auto-diff mode to use for the Hessian.
+    """
+
+    def __init__(
+        self,
+        *names: str,
+        model: Model,
+        component: Literal["log_prob", "log_lik", "log_prior"] = "log_prob",
+        diff_mode: Literal["forward", "reverse"] = "forward",
+    ):
+        self.model = model
+
+        position = self.model.extract_position(names, self.model.state)
+        _, unravel_fn = jax.flatten_util.ravel_pytree(position)
+        self.unravel_fn = unravel_fn
+
+        self._grad_fn = jax.grad(self)
+
+        if diff_mode == "forward":
+            self._hessian_fn = jax.jacfwd(self._grad_fn)
+        elif diff_mode == "reverse":
+            self._hessian_fn = jax.jacrev(self._grad_fn)
+        else:
+            raise ValueError(f"Unrecognized argumetn value {diff_mode=}")
+
+        self.component = component
+        self.diff_mode = diff_mode
+
+    def __call__(self, flat_position: Array) -> Array:
+        return self.log_prob(flat_position=flat_position)
+
+    def log_prob(self, flat_position: Array) -> Array:
+        """
+        Log probability function evaluated at provided ``position``.
+        """
+        position = self.unravel_fn(flat_position)
+        updated_state = self.model.update_state(position, self.model.state)
+        return updated_state[f"_model_{self.component}"].value
+
+    def grad(self, flat_position: Array) -> Array:
+        """
+        Gradient of the log probability function with respect to the ``position``.
+        """
+        return self._grad_fn(flat_position)
+
+    def hessian(self, flat_position: Array) -> Array:
+        """
+        Hessian of the log probability function with respect to the ``position``.
+        """
+        return self._hessian_fn(flat_position)

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -1234,6 +1234,29 @@ class Model:
         subgraph = self.var_graph.subgraph(nodes_to_include)
         return subgraph
 
+    def parental_submodel(self, *of: Var | Node) -> Model:
+        """
+        Returns a new model that consists only of the given variables and nodes and \
+        their parent variables and nodes. The new model contains copies of these \
+        variables and nodes.
+        """
+        nodes_to_include = set()
+
+        for node in of:
+            if isinstance(node, Var):
+                nodes_to_include.update(nx.ancestors(self.var_graph, node))
+            else:
+                nodes_to_include.update(nx.ancestors(self.node_graph, node))
+            nodes_to_include.add(node)
+
+        copy_of_nodes_to_include = deepcopy(nodes_to_include)
+
+        for node in copy_of_nodes_to_include:
+            if hasattr(node, "_unset_model"):
+                node._unset_model()
+
+        return Model(list(copy_of_nodes_to_include))
+
     @property
     def log_lik(self) -> Array:
         """

--- a/liesel/model/model.py
+++ b/liesel/model/model.py
@@ -8,7 +8,7 @@ import logging
 import re
 import warnings
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from types import MappingProxyType
 from typing import IO, Any, Literal, TypeVar
@@ -1555,6 +1555,34 @@ class Model:
             height=height,
             prog=prog,
         )
+
+    def extract_position(
+        self,
+        position_keys: Sequence[str],
+        model_state: dict[str, NodeState] | None = None,
+    ) -> dict[str, Array]:
+        """
+        Extracts a position from a model state.
+
+        Parameters
+        ----------
+        position_keys
+            An iterable of variable or node names.
+        model_state
+            A dictionary of node names and their corresponding :class:`.NodeState`. \
+            If ``None`` (default), the model's current state is used.
+        """
+        model_state = model_state if model_state is not None else self.state
+        position = {}
+
+        for key in position_keys:
+            try:
+                position[key] = model_state[key].value
+            except KeyError:
+                node_key = self.vars[key].value_node.name
+                position[key] = model_state[node_key].value
+
+        return position
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -2087,6 +2087,35 @@ class Var:
             prog=prog,
         )
 
+    def predict(
+        self,
+        samples: dict[str, Array],
+        newdata: dict[str, Array] | None = None,
+    ) -> Array:
+        """
+        Returns an array of predictions for this variable.
+
+        Parameters
+        ----------
+        samples
+            Dictionary of samples at which to evaluate predictions. All values of the \
+            dictionary are assumed to have two leading dimensions corresponding to \
+            ``(nchains, niteration)``.
+        newdata
+            Dictionary of new data at which to evaluate predictions. The keys should \
+            correspond to variable or node names in the model whose values should be \
+            set to the given values before evaluating predictions.
+        """
+
+        if not self.model:
+            raise ValueError(
+                f"For predictions, a model is required, but {self.model=}."
+            )
+
+        submodel = self.model.parental_submodel(self)
+        pred = submodel.predict(samples=samples, predict=[self.name], newdata=newdata)
+        return pred[self.name]
+
     def plot_nodes(
         self,
         show: bool = True,

--- a/liesel/model/nodes.py
+++ b/liesel/model/nodes.py
@@ -2087,6 +2087,7 @@ class Var:
             prog=prog,
         )
 
+    @in_model_method
     def predict(
         self,
         samples: dict[str, Array],
@@ -2107,12 +2108,7 @@ class Var:
             set to the given values before evaluating predictions.
         """
 
-        if not self.model:
-            raise ValueError(
-                f"For predictions, a model is required, but {self.model=}."
-            )
-
-        submodel = self.model.parental_submodel(self)
+        submodel = self.model.parental_submodel(self)  # type: ignore
         pred = submodel.predict(samples=samples, predict=[self.name], newdata=newdata)
         return pred[self.name]
 

--- a/tests/model/test_log_prob.py
+++ b/tests/model/test_log_prob.py
@@ -17,7 +17,6 @@ X = jnp.c_[jnp.ones_like(x1), x1, x2]
 beta = lsl.Var.new_param(
     jnp.zeros(3), lsl.Dist(tfd.Normal, loc=0.0, scale=1.0), name="beta"
 )
-
 mu = lsl.Var.new_calc(jnp.dot, X, beta)
 
 yvar = lsl.Var.new_obs(y, lsl.Dist(tfd.Normal, loc=mu, scale=1.0), name="y")
@@ -53,13 +52,30 @@ class TestLogProb:
 class TestFlatLogProb:
     @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
     def test_log_prob(self, component) -> None:
-        logprob_fn = lsl.FlatLogProb("beta", model=model, component=component)
+        logprob_fn = lsl.FlatLogProb(model, component=component)
         logprob = jax.jit(logprob_fn)(jnp.array([1.0, 2.0, 3.0]))
         assert not jnp.isnan(logprob)
 
     @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
+    def test_log_prob_names(self, component) -> None:
+        mu = lsl.Var.new_param(0.0, name="mu")
+        sigma = lsl.Var.new_param(1.0, name="sigma")
+        y = lsl.Var.new_obs(1.0, lsl.Dist(tfd.Normal, loc=mu, scale=sigma), name="y")
+        model = lsl.Model([y])
+
+        logprob_fn = lsl.FlatLogProb(model, param_names=["mu"], component=component)
+        logprob = jax.jit(logprob_fn)(jnp.array([1.0]))
+        assert not jnp.isnan(logprob)
+
+        logprob_fn = lsl.FlatLogProb(
+            model, param_names=["mu", "sigma"], component=component
+        )
+        logprob = jax.jit(logprob_fn)(jnp.array([1.0, 2.0]))
+        assert not jnp.isnan(logprob)
+
+    @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
     def test_grad(self, component) -> None:
-        logprob_fn = lsl.FlatLogProb("beta", model=model, component=component)
+        logprob_fn = lsl.FlatLogProb(model, component=component)
         result = jax.jit(logprob_fn.grad)(jnp.array([1.0, 2.0, 3.0]))
 
         assert not jnp.any(jnp.isnan(result))
@@ -68,9 +84,7 @@ class TestFlatLogProb:
     @pytest.mark.parametrize("diff_mode", ("forward", "reverse"))
     @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
     def test_hessian(self, diff_mode, component) -> None:
-        logprob_fn = lsl.FlatLogProb(
-            "beta", model=model, component=component, diff_mode=diff_mode
-        )
+        logprob_fn = lsl.FlatLogProb(model, component=component, diff_mode=diff_mode)
         result = jax.jit(logprob_fn.hessian)(jnp.array([1.0, 2.0, 3.0]))
 
         assert not jnp.any(jnp.isnan(result))

--- a/tests/model/test_log_prob.py
+++ b/tests/model/test_log_prob.py
@@ -1,0 +1,77 @@
+import jax
+import jax.numpy as jnp
+import pytest
+import tensorflow_probability.substrates.jax.distributions as tfd
+
+import liesel.model as lsl
+
+key = jax.random.PRNGKey(42)
+k1, k2, k3 = jax.random.split(key, 3)
+n = 200
+y = jax.random.normal(k1, (n,))
+x1 = jax.random.uniform(k2, (n,))
+x2 = jax.random.uniform(k3, (n,))
+
+X = jnp.c_[jnp.ones_like(x1), x1, x2]
+
+beta = lsl.Var.new_param(
+    jnp.zeros(3), lsl.Dist(tfd.Normal, loc=0.0, scale=1.0), name="beta"
+)
+
+mu = lsl.Var.new_calc(jnp.dot, X, beta)
+
+yvar = lsl.Var.new_obs(y, lsl.Dist(tfd.Normal, loc=mu, scale=1.0), name="y")
+
+model = lsl.Model([yvar])
+
+
+class TestLogProb:
+    @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
+    def test_log_prob(self, component) -> None:
+        logprob_fn = lsl.LogProb(model, component=component)
+        logprob = jax.jit(logprob_fn)({"beta": jnp.array([1.0, 2.0, 3.0])})
+        assert not jnp.isnan(logprob)
+
+    @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
+    def test_grad(self, component) -> None:
+        logprob_fn = lsl.LogProb(model, component=component)
+        result = jax.jit(logprob_fn.grad)({"beta": jnp.array([1.0, 2.0, 3.0])})
+
+        assert not jnp.any(jnp.isnan(result["beta"]))
+        assert result["beta"].shape == (3,)
+
+    @pytest.mark.parametrize("diff_mode", ("forward", "reverse"))
+    @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
+    def test_hessian(self, diff_mode, component) -> None:
+        logprob_fn = lsl.LogProb(model, component=component, diff_mode=diff_mode)
+        result = jax.jit(logprob_fn.hessian)({"beta": jnp.array([1.0, 2.0, 3.0])})
+
+        assert not jnp.any(jnp.isnan(result["beta"]["beta"]))
+        assert result["beta"]["beta"].shape == (3, 3)
+
+
+class TestFlatLogProb:
+    @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
+    def test_log_prob(self, component) -> None:
+        logprob_fn = lsl.FlatLogProb("beta", model=model, component=component)
+        logprob = jax.jit(logprob_fn)(jnp.array([1.0, 2.0, 3.0]))
+        assert not jnp.isnan(logprob)
+
+    @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
+    def test_grad(self, component) -> None:
+        logprob_fn = lsl.FlatLogProb("beta", model=model, component=component)
+        result = jax.jit(logprob_fn.grad)(jnp.array([1.0, 2.0, 3.0]))
+
+        assert not jnp.any(jnp.isnan(result))
+        assert result.shape == (3,)
+
+    @pytest.mark.parametrize("diff_mode", ("forward", "reverse"))
+    @pytest.mark.parametrize("component", ("log_prob", "log_lik", "log_prior"))
+    def test_hessian(self, diff_mode, component) -> None:
+        logprob_fn = lsl.FlatLogProb(
+            "beta", model=model, component=component, diff_mode=diff_mode
+        )
+        result = jax.jit(logprob_fn.hessian)(jnp.array([1.0, 2.0, 3.0]))
+
+        assert not jnp.any(jnp.isnan(result))
+        assert result.shape == (3, 3)

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -351,6 +351,10 @@ class TestModel:
         assert "x_transformed" in new_model.vars
         assert new_model.vars["x_transformed"].value == pytest.approx(0.54132485)
 
+    def test_extract_position(self, model) -> None:
+        pos = model.extract_position(["z"])
+        assert pos["z"] == pytest.approx(model.nodes["z"].value)
+
 
 @pytest.mark.xfail
 class TestUserDefinedModelNodes:

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -355,6 +355,34 @@ class TestModel:
         pos = model.extract_position(["z"])
         assert pos["z"] == pytest.approx(model.nodes["z"].value)
 
+    def test_update_state(self, model) -> None:
+        pos = {"z": 3.0}
+        state = model.update_state(pos, inplace=False)
+        assert model.extract_position(["z"], model_state=state)["z"] == pytest.approx(
+            3.0
+        )
+        assert model.nodes["z"].value != pytest.approx(3.0)
+
+        # updating the state from above
+        pos = {"sigma_hat": 20.0}
+        state = model.update_state(pos, inplace=False, model_state=state)
+
+        # extracted position from updated state should contain the updated values
+        extracted_pos = model.extract_position(["z", "sigma_hat"], model_state=state)
+        assert extracted_pos["z"] == pytest.approx(3.0)
+        assert extracted_pos["sigma_hat"] == pytest.approx(20.0)
+
+        # original model state should be unchanged
+        assert model.nodes["z"] != pytest.approx(3.0)
+        assert model.vars["sigma_hat"].value != pytest.approx(20.0)
+
+        pos = {"z": 3.0}
+        state = model.update_state(pos, inplace=True)
+        assert model.extract_position(["z"], model_state=state)["z"] == pytest.approx(
+            3.0
+        )
+        assert model.nodes["z"].value == pytest.approx(3.0)
+
 
 @pytest.mark.xfail
 class TestUserDefinedModelNodes:

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -402,6 +402,24 @@ class TestPredictions:
         assert pred["mu"].shape == (4, 3, 500)
         assert len(pred) == len(model.vars)
 
+    def test_predict_with_unused_samples(self, model) -> None:
+        samples = {
+            "sigma_hat": tfd.Uniform().sample((4, 3), rnd.PRNGKey(6)),
+            "beta_hat": tfd.Uniform().sample((4, 3, 2), rnd.PRNGKey(6)),
+            "unused": tfd.Uniform().sample((4, 3, 2), rnd.PRNGKey(6)),
+        }
+
+        # manual prediction
+        manual_pred = jnp.einsum(
+            "nk,...k->...n", model.vars["X"].value, samples["beta_hat"]
+        )
+
+        # predictions at current values for all vars
+        pred = model.predict(samples=samples)
+        assert jnp.allclose(pred["mu"], manual_pred)
+        assert pred["mu"].shape == (4, 3, 500)
+        assert len(pred) == len(model.vars)
+
     def test_predict_for_specific_var(self, model) -> None:
         samples = {
             "sigma_hat": tfd.Uniform().sample((4, 3), rnd.PRNGKey(6)),


### PR DESCRIPTION
This PR implements two classes that provide convenience for Liesel models: `lsl.LogProb` and `lsl.FlatLogProb`. The idea is to provide easy, direct access to a Liesel model's log prob, log lik and log prior in the form of functions that accept 

- a dictionary of variable names and corresponding values to use (`lsl.LogProb`)
- a flat array of variable values to use (`lsl.FlatLogProb`).

Why does this help? I like it a lot for debugging. These classes can also be used by users to build Liesel-specific inference tools. Fundamentally, the functionality is related to the `LieselInterface`. The main differences are: `lsl.LogProb` and `lsl.FlatLogProb` can also be used to single out the likelihood or the prior, and they accept position dictionaries instead of model states, which makes them more user-friendly. 

One could easily build something very similar in a general way for all `gs.ModelInterface` classes, i.e. something that accepts positions directly and offers gradients and hessians via Jax directly -- and maybe that is something we should do instead (or also). The `gs.ModelInterface` classes do, however, not distinguish between log prob, log lik and log prior, so they could only evaluate the log prob and its derivatives.

Here are examples:

```python
mu = lsl.Var.new_param(0.0, name="mu")
sigma = lsl.Var.new_param(1.0, name="sigma")
y = lsl.Var.new_obs(1.0, lsl.Dist(tfd.Normal, loc=mu, scale=sigma), name="y")
model = lsl.Model([y])
```

### LogProb

```python
logprob = lsl.LogProb(model, component="log_prob") 
# component could also be 'log_lik' or 'log_prior'

logprob({"mu": 1.0}) # Array(-0.9189385, dtype=float32)
logprob.log_prob({"mu": 1.0}) # Array(-0.9189385, dtype=float32) (same as direct call)
logprob.grad({"mu": 1.0}) # {'mu': Array(0., dtype=float32, weak_type=True)}
logprob.hessian({"mu": 1.0}) # {'mu': {'mu': Array(-1., dtype=float32, weak_type=True)}}
```

### FlatLogProb

```python
logprob = lsl.FlatLogProb(model, param_names=["mu"])
# component could also be 'log_lik' or 'log_prior'

logprob(jnp.array([1.0])) # Array(-0.9189385, dtype=float32)
logprob.log_prob(jnp.array([1.0])) # Array(-0.9189385, dtype=float32) (same as direct call)
logprob.grad(jnp.array([1.0])) # Array([0.], dtype=float32)
logprob.hessian(jnp.array([1.0])) # Array([[-1.]], dtype=float32)
```

I think providing both a flattened and a non-flattened version makes sense, because the first one (`lsl.LogProb`) may be easier to understand and use in many cases, while the second one `lsl.FlatLogProb` may be more handy to build upon in some cases. 