### PR TITLE
Switch from PyGraphviz to pydot

### DIFF
--- a/liesel/model/viz.py
+++ b/liesel/model/viz.py
@@ -135,28 +135,19 @@ def _prepare_figure(graph, width, height, prog):
     fig, axis = plt.subplots()
     fig.set_size_inches(width, height)
 
-    if _is_pygraphviz_installed():
-        pos = nx.drawing.nx_agraph.graphviz_layout(graph, prog=prog)
-    else:
+    try:
+        pos = nx.nx_pydot.pydot_layout(graph, prog=prog)
+    except FileNotFoundError:
         logger.warning(
-            "PyGraphviz was not found in the current environment. "
-            "Using fallback graph layout. Consider installing PyGraphviz: "
-            "https://pygraphviz.github.io/documentation/stable/install.html"
+            "Graphviz not found in PATH. Using fallback graph layout. "
+            "Consider installing Graphviz: https://graphviz.org/download"
         )
-        pos = nx.fruchterman_reingold_layout(graph)
+
+        # node_size = {node: 2.0 for node in graph}
+        # pos = nx.forceatlas2_layout(graph, node_size=node_size, seed=42)
+        pos = nx.kamada_kawai_layout(graph.to_undirected())
 
     return fig, axis, pos
-
-
-def _is_pygraphviz_installed():
-    """Checks if pygraphviz is installed."""
-
-    try:
-        import pygraphviz  # noqa: F401
-    except ImportError:
-        return False
-    else:
-        return True
 
 
 def _add_nodes_with_distribution_to_plot(graph, axis, pos):

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,12 +26,13 @@ install_requires =
     matplotlib>=3.5
     networkx>=2.6
     numpy>=1.22,!=1.24.0,<2.0
+    optax>=0.1.7
     pandas>=1.4
+    pydot>=3.0
     scipy>=1.8.0
     seaborn>=0.13
     tensorflow-probability>=0.17
     tqdm>=4.62
-    optax>=0.1.7
 
 [options.extras_require]
 dev =
@@ -41,17 +42,17 @@ dev =
     mypy
     myst-nb>=1.0.0
     pre-commit
+    pydata-sphinx-theme
     pytest
     pytest-cov
     pyupgrade
+    rtds-action
     sphinx>=7.2.6
     sphinx-autodoc-typehints>=1.19
-    pydata-sphinx-theme
     sphinx-book-theme>=1.1.0
     sphinx-copybutton>=0.5
     sphinx-remove-toctrees>=0.0.3
     types-deprecated
-    rtds-action
 pymc =
     pymc>=5.9
 


### PR DESCRIPTION
[Pydot](https://github.com/pydot/pydot) is an alternative to PyGraphviz that is written in pure Python and hence does not require a compiler or the Graphviz headers to install. It only depends on the Graphviz binaries, which makes it a lot easier to use, especially on Windows. As far as I have tested the library, the generated graphs look the same. Combined with https://github.com/liesel-devs/rliesel/pull/9, this PR makes Liesel and RLiesel much more accessible to less tech-savvy people.

Also, I tried to improve the fallback graph layout that is used if Graphviz is missing. Which one do you like better, @GianmarcoCallegher, @jobrachem?

**forceatlas2_layout()**

``` py
node_size = {node: 2.0 for node in graph}
pos = nx.forceatlas2_layout(graph, node_size=node_size, seed=42)
```

![forceatlas2_layout](https://github.com/user-attachments/assets/9c788ad7-bd87-4bab-ab5b-b1c37817575f)

**kamada_kawai_layout()**

``` py
pos = nx.kamada_kawai_layout(graph.to_undirected())
```

![kamada_kawai_layout](https://github.com/user-attachments/assets/ef474ed9-e045-42b1-b22a-38dcae41bb72)

Both are pretty readable, but the second one doesn't depend on a random seed and might be more stable, I think...

Best,
Hannes