### PR TITLE
Donate model state and kernel states in engine

### DIFF
--- a/src/liesel/goose/engine.py
+++ b/src/liesel/goose/engine.py
@@ -371,7 +371,8 @@ class Engine:
                 self._sample_many,
                 in_axes=(0, None, 0, 0),
                 out_axes=(None, 0, 0, 0, 0, 0, 0),
-            )
+            ),
+            donate_argnames=("kernel_states", "model_state"),
         )
 
     @property


### PR DESCRIPTION
Jax supports donation of arguments to avoid memory reallocation. This PR enables the use in the engine. There shouldn't be a large speed improvements when the states are small and the number of iterations glued into one compiled call is large (like the default). Nonetheless, a small improvement.