### PR TITLE
One place of truth for version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liesel"
-version = "0.4.1"
+dynamic = ["version"]
 description = "A probabilistic programming framework with a focus on semi-parametric regression"
 readme = "README.md"
 authors = [
@@ -104,6 +104,9 @@ extend-select = [
 ]
 
 extend-ignore = []
+
+[tool.hatch.version]
+path = "src/liesel/__version__.py"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/uv.lock
+++ b/uv.lock
@@ -845,7 +845,6 @@ wheels = [
 
 [[package]]
 name = "liesel"
-version = "0.4.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },


### PR DESCRIPTION
This PR removes the need to set the version number in two place (`pyproject.toml` and `__version__.py`). Now, only the latter is needed.