### PR TITLE
Fix model copy arg

### DIFF
--- a/src/liesel/model/model.py
+++ b/src/liesel/model/model.py
@@ -1009,22 +1009,19 @@ class Model:
         their parent variables and nodes. The new model contains copies of these \
         variables and nodes.
         """
+
         nodes_to_include = set()
 
         for node in of:
             if isinstance(node, Var):
                 nodes_to_include.update(nx.ancestors(self.var_graph, node))
+
             else:
                 nodes_to_include.update(nx.ancestors(self.node_graph, node))
+
             nodes_to_include.add(node)
 
-        copy_of_nodes_to_include = deepcopy(nodes_to_include)
-
-        for node in copy_of_nodes_to_include:
-            if hasattr(node, "_unset_model"):
-                node._unset_model()
-
-        return Model(list(copy_of_nodes_to_include), to_float32=self._to_float32)
+        return Model(list(nodes_to_include), to_float32=self._to_float32, copy=True)
 
     @property
     def log_lik(self) -> Array:

--- a/src/liesel/model/model.py
+++ b/src/liesel/model/model.py
@@ -819,7 +819,9 @@ class Model:
         self._to_float32 = to_float32
         if grow:
             model = (
-                GraphBuilder(to_float32=to_float32).add(*nodes_and_vars).build_model()
+                GraphBuilder(to_float32=to_float32)
+                .add(*nodes_and_vars)
+                .build_model(copy=copy)
             )
             nodes_and_vars = [*model.nodes.values(), *model.vars.values()]
             model.pop_nodes_and_vars()

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -111,6 +111,14 @@ class TestModel:
         assert len(nodes_and_vars[0]) == len(model.nodes) - 3
         assert len(nodes_and_vars[1]) == len(model.vars)
 
+    def test_copy_model(self, model: Model) -> None:
+        vars_ = list(model.vars.values())
+        model_copy = Model(vars_, copy=True)
+        assert len(model_copy.vars) == len(model.vars)
+
+        with pytest.raises(RuntimeError):
+            Model(vars_, copy=False)
+
     def test_copy_unfrozen(self, model: Model) -> None:
         """Verifies that the vars and nodes are unfrozen."""
         nodes_and_vars = model.copy_nodes_and_vars()


### PR DESCRIPTION
I noticed that the argument `lsl.Model(copy=...)` was not properly propagated to `lsl.GraphBuilder.build_model(copy=...)` in the init. This PR fixes the issue, includes a small test and refactors `lsl.Model.parental_submodel()` to make use of the now functional copy argument.