### PR TITLE
Revert model copy

### DIFF
--- a/src/liesel/model/model.py
+++ b/src/liesel/model/model.py
@@ -819,9 +819,7 @@ class Model:
         self._to_float32 = to_float32
         if grow:
             model = (
-                GraphBuilder(to_float32=to_float32)
-                .add(*nodes_and_vars)
-                .build_model(copy=copy)
+                GraphBuilder(to_float32=to_float32).add(*nodes_and_vars).build_model()
             )
             nodes_and_vars = [*model.nodes.values(), *model.vars.values()]
             model.pop_nodes_and_vars()

--- a/src/liesel/model/model.py
+++ b/src/liesel/model/model.py
@@ -1021,7 +1021,11 @@ class Model:
 
             nodes_to_include.add(node)
 
-        return Model(list(nodes_to_include), to_float32=self._to_float32, copy=True)
+        copy_of_nodes_to_include = deepcopy(nodes_to_include)
+
+        return Model(
+            list(copy_of_nodes_to_include), to_float32=self._to_float32, copy=False
+        )
 
     @property
     def log_lik(self) -> Array:


### PR DESCRIPTION
After having merged https://github.com/liesel-devs/liesel/pull/306, I have now encountered irregular tracer leaks into the model state when using `Model.predict` inside jitted functions. For now, I think it might be best to revert the changes in https://github.com/liesel-devs/liesel/pull/306 until we better understand what is going wrong.