### PR TITLE
Make Model.parental_submodel more robust

### DIFF
--- a/src/liesel/model/model.py
+++ b/src/liesel/model/model.py
@@ -1019,11 +1019,12 @@ class Model:
 
             nodes_to_include.add(node)
 
-        copy_of_nodes_to_include = deepcopy(nodes_to_include)
+        nodes, vars_ = self.copy_nodes_and_vars()
+        nodes_and_vars = nodes | vars_
 
-        return Model(
-            list(copy_of_nodes_to_include), to_float32=self._to_float32, copy=False
-        )
+        copy_of_nodes_to_include = [nodes_and_vars[n.name] for n in nodes_to_include]
+
+        return Model(copy_of_nodes_to_include, to_float32=self._to_float32, copy=False)
 
     @property
     def log_lik(self) -> Array:


### PR DESCRIPTION
- Model.parental_submodel creates copies of the nodes to include in the submodel. This makes it work, because otherwise we would run into problems, since every node is allowed to be part of only one model. 
- Currently, the copying is done manually by calling `copy.deepcopy`. The problem is that this does not really make sure that the model is unset from the relevant nodes. This sometimes lead to problems.
- In this PR, I call Model.copy_nodes_and_vars first, and then select the relevant nodes from these copies. This makes sure that the model is properly unset from all relevant nodes.