### PR TITLE
Improved NaN handling in IWLS proposals

### DIFF
--- a/src/liesel/goose/iwls.py
+++ b/src/liesel/goose/iwls.py
@@ -58,9 +58,41 @@ class IWLSKernel(
     ModelMixin, TransitionMixin[IWLSKernelState, IWLSTransitionInfo], ReprMixin
 ):
     """
-    An IWLS kernel with dual averaging and an (optional) user-defined function
-    for computing the Cholesky decomposition of the Fisher information matrix,
-    implementing the :class:`.liesel.goose.types.Kernel` protocol.
+    An IWLS kernel with dual averaging and an (optional) user-defined function for
+    computing the Cholesky decomposition of the Fisher information matrix, implementing
+    the :class:`.liesel.goose.types.Kernel` protocol.
+
+    Parameters
+    ----------
+    position_keys
+        Sequence of position keys (variable names) handled by this kernel.
+    chol_info_fn
+        A custom function that takes a model state and returns the Cholesky
+        decomposition of the information matrix to produce the IWLS proposal. By
+        default, this will be the Cholesky decomposition of the observed negative
+        hessian at the current values, i.e. the current observed information.
+    initial_step_size
+        Value at which to start step size tuning.
+    da_tune_step_step_size
+        Whether to tune the step size suing dual averaging.
+    da_target_accept
+        Target acceptance probability for dual averaging algorithm.
+    da_gamma
+        The adaptation regularization scale.
+    da_kappa
+        The adaptation relaxation exponent.
+    da_t0
+        The adaptation iteration offset.
+    identifier
+        An string acting as a unique identifier for this kernel.
+    fallback_chol_info
+        What do do if the Cholesky decomposition of the observed information matrix
+        fails. If ``"identity"``, uses an identity matrix as the Cholesky factor. If
+        ``"chol_of_modified_info"``, performs an eigendecomposition of the negative
+        Hessian and clips the eigenvalues to ``1e-5``. This can be interpreted as
+        replacing the observed negative Hessian with a very similar positive definite
+        matrix. This is slow, because it performs an eigendecomposition and two cholesky
+        factorizations. If ``None``, does nothing.
     """
 
     error_book: ClassVar[dict[int, str]] = {


### PR DESCRIPTION
Sometimes the IWLS proposal fails, because the Hessian is indefinite. This shows itself in a Cholesky factor filled with `nan` values. A previous PR (#331) introduced a default salt added to the diagonal of the negative Hessian, and while this helps with robustness, it can still fail badly. 

This PR introduces a conditional statement check for nans in the Cholesky factor. The use controls the action to be taken via an init argument. The current option are "identity" and "chol_of_modified_info". 

The former ("identity") just uses an identity matrix as the Cholesky factor, essentially turning this iteration into an ordinary MALA sampler. This is super fast and numerically robust, although of course there may be situations where this does not lead to good samples.

The latter ("chol_of_modified_info") performs an eigendecomposition of the negative Hessian and clips the eigenvalues to `1e-5`. This can be interpreted as replacing the observed negative Hessian with a very similar positive definite matrix. This is slow, because it performs an eigendecomposition and two cholesky factorizations. The computational cost does not necessarily lead to good proposals, because it can lead to very high variances.

The user can also turn off the fallback option by passing None.

In any case, the IWLS kernel also saves detailed error codes that concern `nan` values in the Cholesky factor. This makes it possible for users to know what is happening, so they can determine what to do.


## Illustration

This came up when working with tensor product splines in liesel-gam. This is the model:

$$
z_i = \beta_0 + s(x_i) + s(y_i) + s(x_i, y_i) + \epsilon_i
$$

<img width="546" height="482" alt="image" src="https://github.com/user-attachments/assets/d0cbc38e-69b8-4f01-914e-3f248e3c9b5b" />


### Without fallback

The variances of the interaction term don't sample at all.

<img width="783" height="250" alt="image" src="https://github.com/user-attachments/assets/a5c1498d-6618-42a1-b5bf-fbcd3c02c8b5" />

<img width="972" height="255" alt="image" src="https://github.com/user-attachments/assets/443b9baa-a6a3-44c5-bf23-f3fde574d622" />

<img width="995" height="584" alt="image" src="https://github.com/user-attachments/assets/69a18481-c19d-49d5-9b42-88771fe9a761" />


### With fallback

While not looking amazing, the variances now sample, when using the identity fallback option. In this case, I also used the default (tuned) version of IWLS.

<img width="798" height="252" alt="image" src="https://github.com/user-attachments/assets/d9c98513-fcef-40ac-bdd9-1946d8ed2a39" />

<img width="872" height="207" alt="image" src="https://github.com/user-attachments/assets/83e3e3df-fcc2-432c-89d7-027c79aa996d" />

<img width="995" height="584" alt="image" src="https://github.com/user-attachments/assets/322d9d92-648f-45bf-aeec-8f2dd7d2a842" />


## Other solutions / this is no fix-all

To be fair, sampling of the tensor product variances overall works much better when better initial values for the variances are used together with `IWLSKernel.untuned`. The results from above use initial values of `1.0` for both variances of the tensor product. If I lower them to `0.1` and use the untuned IWLS, things look completely fine. In contrast, the tuned IWLS fails for tau_ps(x)1 even with the smaller start values.

What I want to say is: This PR does not include a single fix-all solution. It just a) adds a little numerical robustness to the IWLS kernel and b) adds more information about the point of failure in case of numerical problems in the IWLS kernel through the additional error codes.
