### PR TITLE
Include Var info in Calc update error

### DIFF
--- a/src/liesel/model/nodes.py
+++ b/src/liesel/model/nodes.py
@@ -917,7 +917,11 @@ class Calc(Node):
         try:
             self._value = self.function(*args, **kwargs)
         except Exception as e:
-            raise RuntimeError(f"Error while updating {self}.") from e
+            if self.var is not None:
+                msg = f"Error while updating {self} of {self.var}."
+            else:
+                msg = f"Error while updating {self}."
+            raise RuntimeError(msg) from e
         self._outdated = False
         return self
 

--- a/tests/model/test_node.py
+++ b/tests/model/test_node.py
@@ -356,6 +356,20 @@ def test_calculator_error_in_update() -> None:
         calc.update()
 
 
+def test_calculator_error_in_update_mentions_var() -> None:
+    x = Value(2.0, _name="x")
+
+    def update_fn(x):
+        raise ValueError("Testing error message.")
+
+    var = Var.new_calc(update_fn, x=x, name="broken", _update_on_init=False)
+    with pytest.raises(
+        RuntimeError,
+        match=r'while updating Calc\(name="broken_calc"\) of Var\(name="broken"\)\.',
+    ):
+        var.update()
+
+
 def test_transient_calculator_error_in_update() -> None:
     x = Value(2.0, _name="x")
 


### PR DESCRIPTION
Tiny PR that enriches calculator error messages with info about the calc'c Var if it has one.