### PR TITLE
Correct loo reff computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ docs/source/tutorials/qmd/.Rprofile
 docs/render.sh
 doctests.py
 docs/batch-and-split-design.md
+/.scratch

--- a/src/liesel/goose/summary_m.py
+++ b/src/liesel/goose/summary_m.py
@@ -1169,7 +1169,7 @@ def _apply_loo_scale(
 
 def loo(
     lpp: Mapping[str, jax.typing.ArrayLike] | jax.typing.ArrayLike,
-    samples: dict[str, jax.typing.ArrayLike] | None,
+    samples: dict[str, jax.typing.ArrayLike] | None = None,
     reff: float | None = None,
     scale: Literal["log", "negative_log", "deviance"] = "log",
 ) -> _LieselELPDData:
@@ -1182,20 +1182,14 @@ def loo(
     lpp
         Dictionary or array of pointwise log probability evaluations.
         If passed as a dictionary, each value is expected to have shape
-        ``(nsamples, nchains, ...)``.
-        If passed as an array, it is assumed to have shape ``(nsamples, nchains, n)``.
+        ``(nchains, ndraws, ...)``.
+        If passed as an array, it is assumed to have shape ``(nchains, ndraws, n)``.
     samples
-        Dictionary of samples at which to evaluate log probs. If ``samples``
-        contains entries for weak variables or for nodes in :attr:`.model_nodes`
-        they are ignored.
-    newdata
-        Dictionary of new data at which to evaluate log probs. The keys should \
-        correspond to variable or node names in the model whose values should be \
-        set to the given values before evaluating predictions. If ``None`` \
-        (default), the current variable values are used.
+        Retained for backwards compatibility and ignored.
     reff
         Relative MCMC efficiency, ess / n i.e. number of effective samples divided
-        by the number of actual samples. Computed from the samples by default.
+        by the number of actual samples. Computed from the likelihood values by
+        default. For independent draws, pass ``1.0``.
     scale
         Output scale. The options are:
 
@@ -1216,12 +1210,6 @@ def loo(
       https://doi.org/10.1007/s11222-016-9696-4
 
     """
-    if samples is None and reff is None:
-        raise ValueError(
-            "Both 'samples' and 'reff' are None, so relative MCMC efficiency is not "
-            "available."
-        )
-
     if isinstance(lpp, Mapping):
         lpp_by_variable = cast(Mapping[str, jax.typing.ArrayLike], lpp)
         lpp_array = concatenate_arrays_in_dict(lpp_by_variable)
@@ -1230,14 +1218,11 @@ def loo(
 
     lpp_array = np.asarray(lpp_array)
     idat = az.from_dict({"log_likelihood": {"observed": lpp_array}})
-    if reff is None and samples is not None:
-        avg_ess = (
-            SamplesSummary(samples, which=["ess_bulk"])
-            .to_dataframe()["ess_bulk"]
-            .mean()
-        )
+    if reff is None:
         nsamples = lpp_array.shape[0] * lpp_array.shape[1]
-        reff = avg_ess / nsamples
+        shift = lpp_array.max(axis=(0, 1), keepdims=True)
+        likelihood = np.exp(lpp_array - shift)
+        reff = float(np.mean(az.ess(likelihood, method="mean") / nsamples))
     # now we assume reff is not None
 
     return _apply_loo_scale(az.loo(idat, reff=reff), scale)

--- a/tests/goose/test_summary_m.py
+++ b/tests/goose/test_summary_m.py
@@ -1,5 +1,7 @@
 from itertools import product
+from types import SimpleNamespace
 
+import arviz as az
 import jax.numpy as jnp
 import jax.random as rnd
 import numpy as np
@@ -623,5 +625,28 @@ def test_loo(model):
     assert loo_deviance.p_loo == pytest.approx(5.829, abs=0.01)
     assert loo_deviance.se == pytest.approx(2 * 15.777, abs=0.01)
 
-    with pytest.raises(ValueError, match="relative MCMC efficiency"):
-        loo(lpp, None)
+
+def test_loo_relative_efficiency(monkeypatch):
+    reffs = []
+
+    def fake_loo(_, reff):
+        reffs.append(reff)
+        return SimpleNamespace(elpd=0.0, p=0.0)
+
+    monkeypatch.setattr("liesel.goose.summary_m.az.loo", fake_loo)
+
+    trajectory = np.sin(np.linspace(0.0, 4.0 * np.pi, 400)).reshape(4, 100)
+    lpp = np.stack((trajectory, 0.5 * trajectory, -trajectory), axis=-1) - 10_000.0
+    likelihood = np.exp(lpp - lpp.max(axis=(0, 1), keepdims=True))
+    expected = float(np.mean(az.ess(likelihood, method="mean") / 400))
+
+    loo(lpp)
+    loo(lpp, {"unrelated": np.zeros((4, 100))})
+    loo(np.full((4, 100, 3), -10_000.0))
+
+    assert reffs[:2] == pytest.approx([expected, expected], rel=1e-4)
+    assert reffs[2] == pytest.approx(1.0)
+
+    monkeypatch.setattr(az, "ess", lambda *_args, **_kwargs: pytest.fail())
+    loo(lpp, reff=0.25)
+    assert reffs[3] == pytest.approx(0.25)


### PR DESCRIPTION
Fixes the LOO effective sample size calculation to use likelihood values instead of model parameters. Existing code keeps working, and tests cover the change.