### PR TITLE
Preserve initial states when multiple_chains=True

### DIFF
--- a/src/liesel/goose/builder.py
+++ b/src/liesel/goose/builder.py
@@ -304,6 +304,8 @@ class EngineBuilder:
         """
         if not multiple_chains:
             model_states = stack_leaves(model_state for _ in range(self._num_chains))
+        else:
+            model_states = model_state
 
         self._model_state = Option(model_states)
 

--- a/tests/goose/test_builder.py
+++ b/tests/goose/test_builder.py
@@ -24,6 +24,15 @@ def test_seed_input():
     assert jnp.all(builder._jitter_key == builder2._jitter_key)
 
 
+def test_initial_values_multiple_chains():
+    builder = EngineBuilder(seed=1, num_chains=2)
+    states = {"x": jnp.array([1.0, 2.0]), "y": jnp.array([[3.0], [4.0]])}
+
+    builder.set_initial_values(states, multiple_chains=True)
+
+    assert builder.model_state.unwrap() is states
+
+
 def test_jitter_fns():
     con = DictInterface(lambda ms: -0.5 * ms["x"] ** 2 - 0.5 * ms["y"])
     ms = {"x": jnp.array(1), "y": jnp.array(-1)}


### PR DESCRIPTION
This is a minimal bug fix.

Fixes EngineBuilder.set_initial_values so that when multiple_chains=True the provided model_state is preserved instead of being stacked. 