### PR TITLE
Relax Position typing for plain dicts

### DIFF
--- a/src/liesel/types.py
+++ b/src/liesel/types.py
@@ -1,5 +1,9 @@
 """Types shared by Liesel's modeling and sampling interfaces."""
 
-from typing import Any, NewType
+from typing import TYPE_CHECKING, Any, NewType
 
-Position = NewType("Position", dict[str, Any])
+if TYPE_CHECKING:
+    Position = dict[str, Any]
+else:
+    # Accept plain dictionaries statically while preserving Position(d) is d.
+    Position = NewType("Position", dict[str, Any])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,9 @@
+from liesel.types import Position
+
+
+def test_position_accepts_dict_without_copying() -> None:
+    values: dict[str, float] = {"mu": 1.0}
+    position: Position = values
+
+    assert position is values
+    assert Position(values) is values


### PR DESCRIPTION
Update `liesel.types.Position` to use a `TYPE_CHECKING` alias to `dict[str, Any]` for static type checkers, while keeping the runtime `NewType` behavior so `Position(values)` returns the same object. 


This fixes static typing diagnostics that are more annoying than informative, e.g. when supplying a perfectly reasonable dictionary where, formally, a Position is expected. I think it is unreasonable and not the intended behavior to expect users to always wrap their dictionaries in `Position`.