### PR TITLE
Improve bijected_var access/typing

### DIFF
--- a/src/liesel/model/nodes.py
+++ b/src/liesel/model/nodes.py
@@ -1958,7 +1958,7 @@ class Var:
             distribution=distribution,
         )
         var.value_node.monitor = True
-        if var.bijected_var is not None:
+        if var.has_bijected_var:
             var.bijected_var.parameter = True
         else:
             var.parameter = True
@@ -2580,11 +2580,22 @@ class Var:
         return self
 
     @property
-    def bijected_var(self) -> Var | None:
+    def bijected_var(self) -> Var:
         """
         Transformed variable.
         Either supplied manually or automatically created by :meth:`.biject`.
+
+        Raises
+        ------
+        RuntimeError
+            If no bijected variable exists. Use :attr:`.has_bijected_var` to check
+            whether one exists without raising an error.
         """
+        if self._bijected_var is None:
+            raise RuntimeError(
+                f"{self} has no bijected variable. "
+                "Apply .biject() or .transform() first, or assign .bijected_var."
+            )
         return self._bijected_var
 
     @bijected_var.setter
@@ -2598,6 +2609,11 @@ class Var:
             raise ValueError(f"{value} is on in the inputs or kwinputs of {self}")
 
         self._bijected_var = value
+
+    @property
+    def has_bijected_var(self) -> bool:
+        """Whether a transformed variable has been created or supplied manually."""
+        return self._bijected_var is not None
 
     @in_model_method
     def all_output_nodes(

--- a/tests/model/test_bijections.py
+++ b/tests/model/test_bijections.py
@@ -13,12 +13,6 @@ import liesel.goose as gs
 import liesel.model as lsl
 
 
-def _require_bijected_var(var: lsl.Var) -> lsl.Var:
-    bijected_var = var.bijected_var
-    assert bijected_var is not None
-    return bijected_var
-
-
 class TestBijectParametersValidation:
     """Test validation in Dist.biject_parameters."""
 
@@ -388,11 +382,29 @@ class TestBijectParametersSuccess:
         dist = lsl.Dist(tfd.Gamma, concentration, scale)
         assert dist._dtype == jnp.dtype("float64")
         dist.biject_parameters()
-        assert _require_bijected_var(concentration).value.dtype == jnp.dtype("float64")
+        assert concentration.bijected_var.value.dtype == jnp.dtype("float64")
         jax.config.update("jax_enable_x64", False)
 
 
 class TestVarBiject:
+    def test_bijected_var_requires_transformation(self):
+        variance = lsl.Var.new_param(1.0, name="variance")
+
+        assert not variance.has_bijected_var
+        assert variance.parameter
+        with pytest.raises(RuntimeError, match="variance.*has no bijected variable"):
+            _ = variance.bijected_var
+
+    def test_bijected_var_accepts_array_assignment(self):
+        variance = lsl.Var.new_param(1.0, name="variance", bijector=tfb.Exp())
+
+        assert variance.has_bijected_var
+        log_variance = variance.bijected_var
+        assert log_variance.parameter
+        log_variance.value = jnp.log(0.5)
+
+        assert variance.update().value == pytest.approx(0.5)
+
     def test_bijected_var_manually(self):
         log_scale = lsl.Var.new_param(1.0, name="log_scale")
         scale = lsl.Var.new_calc(jnp.exp, log_scale)
@@ -416,16 +428,16 @@ class TestVarBiject:
         scale = lsl.Var.new_param(1.0, name="scale")
         scale.biject(tfb.Exp())
 
-        assert _require_bijected_var(scale).name == "h(scale)"
+        assert scale.bijected_var.name == "h(scale)"
 
     def test_bijected_var_from_transform(self):
         scale = lsl.Var.new_param(1.0, name="scale")
         scale.transform(tfb.Exp())
 
-        assert _require_bijected_var(scale).name == "scale_transformed"
+        assert scale.bijected_var.name == "scale_transformed"
 
     def test_unnamed_bijected_var(self):
         scale = lsl.Var.new_param(1.0)
         scale.transform(tfb.Exp())
 
-        assert _require_bijected_var(scale).name == ""
+        assert scale.bijected_var.name == ""

--- a/tests/model/test_model_modification.py
+++ b/tests/model/test_model_modification.py
@@ -13,12 +13,6 @@ def _require_dist_node(var: lsl.Var) -> lsl.Dist:
     return dist_node
 
 
-def _require_bijected_var(var: lsl.Var) -> lsl.Var:
-    bijected_var = var.bijected_var
-    assert bijected_var is not None
-    return bijected_var
-
-
 class TestBasicModifyModel:
     def test_biject_variable(self):
         x = lsl.Var.new_obs(jrd.normal(jrd.key(1), (10,)), name="x")
@@ -37,8 +31,8 @@ class TestBasicModifyModel:
 
         scale.biject(tfb.Exp())
 
-        assert _require_bijected_var(scale).name in model.vars
-        assert _require_bijected_var(scale).name in model.parameters
+        assert scale.bijected_var.name in model.vars
+        assert scale.bijected_var.name in model.parameters
         assert scale.name not in model.parameters
 
     def test_rename_variable(self):


### PR DESCRIPTION
Var.bijected_var now raises a clear RuntimeError when no transformed variable exists, along with a new has_bijected_var property for safe checks. This makes bijection handling explicit and avoids implicit None checks in model logic. Updated tests cover missing bijected variables, manual array assignment, and transformed-variable behavior.